### PR TITLE
v2.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.2
+
+- docs: updated the default urls used for connection check in [d66ff76](https://github.com/OutdatedGuy/internet_connection_checker_plus/commit/d66ff768e6a1722f32e044412391ffa488afeee2)
+
 ## 2.4.1
 
 - fix(web): dart isolates not working on web platform in [fa57142](https://github.com/OutdatedGuy/internet_connection_checker_plus/commit/fa571420061af109fc85c4150825b19645fe8b1a)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Add the `internet_connection_checker_plus` package to your `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  internet_connection_checker_plus: ^2.4.1
+  internet_connection_checker_plus: ^2.4.2
 ```
 
 ### 2. Import the package

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -121,7 +121,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.4.1"
+    version: "2.4.2"
   lints:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: internet_connection_checker_plus
 description: "A Flutter package to check your internet connection with subsecond response times, even on mobile networks!"
-version: 2.4.1
+version: 2.4.2
 homepage: https://outdatedguy.rocks
 repository: https://github.com/OutdatedGuy/internet_connection_checker_plus
 


### PR DESCRIPTION
## What's Changed
* docs: updated the default urls used for connection check by @OutdatedGuy in https://github.com/OutdatedGuy/internet_connection_checker_plus/pull/42


**Full Changelog**: https://github.com/OutdatedGuy/internet_connection_checker_plus/compare/v2.4.1...v2.4.2