### PR TITLE
refactor: increased check interval to 10s

### DIFF
--- a/lib/src/internet_connection.dart
+++ b/lib/src/internet_connection.dart
@@ -71,7 +71,7 @@ class InternetConnection {
   /// - If [useDefaultOptions] is `false`, you must provide a non-empty
   /// [customCheckOptions] list.
   InternetConnection.createInstance({
-    this.checkInterval = const Duration(seconds: 5),
+    this.checkInterval = const Duration(seconds: 10),
     List<InternetCheckOption>? customCheckOptions,
     bool useDefaultOptions = true,
   }) : assert(


### PR DESCRIPTION
It was 5s before to check frequently when connectivity_plus package was not used to listen to network changes.