### PR TITLE
fix: type cast error when network changes

### DIFF
--- a/lib/src/internet_connection.dart
+++ b/lib/src/internet_connection.dart
@@ -270,6 +270,7 @@ class InternetConnection {
           _maybeEmitStatusUpdate();
         }
       },
+      onError: (_, __) {},
     );
   }
 }


### PR DESCRIPTION
No idea how this solves the issue, but errors have stopped being reported now

fixes #77