### PR TITLE
Minor cleanup/refactor of some logic

### DIFF
--- a/lib/src/internet_connection.dart
+++ b/lib/src/internet_connection.dart
@@ -169,10 +169,17 @@ class InternetConnection {
   ///
   /// Returns a [Future] that completes with an [InternetCheckResult] indicating
   /// whether the host is reachable or not.
-  Future<InternetCheckResult> _checkReachabilityFor(InternetCheckOption option) async {
+  Future<InternetCheckResult> _checkReachabilityFor(
+    InternetCheckOption option,
+  ) async {
     try {
-      if (customConnectivityCheck != null) return customConnectivityCheck!(option);
-      final response = await http.head(option.uri, headers: option.headers).timeout(option.timeout);
+      if (customConnectivityCheck != null) {
+        return customConnectivityCheck!.call(option);
+      }
+
+      final response = await http
+          .head(option.uri, headers: option.headers)
+          .timeout(option.timeout);
 
       return InternetCheckResult(
         option: option,
@@ -237,8 +244,9 @@ class InternetConnection {
   ///
   /// Returns a [Future] that completes with the [InternetStatus] indicating
   /// the current internet connection status.
-  Future<InternetStatus> get internetStatus async =>
-      await hasInternetAccess ? InternetStatus.connected : InternetStatus.disconnected;
+  Future<InternetStatus> get internetStatus async => await hasInternetAccess
+      ? InternetStatus.connected
+      : InternetStatus.disconnected;
 
   /// Internal method for emitting status updates.
   ///
@@ -253,6 +261,7 @@ class InternetConnection {
     if (_lastStatus != currentStatus) _statusController.add(currentStatus);
 
     _timerHandle = Timer(_checkInterval, _maybeEmitStatusUpdate);
+
     _lastStatus = currentStatus;
   }
 
@@ -282,10 +291,11 @@ class InternetConnection {
   /// [connectivity_plus]: https://pub.dev/packages/connectivity_plus
   void _startListeningToConnectivityChanges() {
     if (_connectivitySubscription != null) return;
-
     _connectivitySubscription = Connectivity().onConnectivityChanged.listen(
       (_) {
-        if (_statusController.hasListener) _maybeEmitStatusUpdate();
+        if (_statusController.hasListener) {
+          _maybeEmitStatusUpdate();
+        }
       },
       onError: (_, __) {},
     );

--- a/lib/src/internet_connection.dart
+++ b/lib/src/internet_connection.dart
@@ -162,21 +162,17 @@ class InternetConnection {
   /// The handle for the timer used for periodic status checks.
   Timer? _timerHandle;
 
+  /// Connectivity subscription.
+  StreamSubscription<List<ConnectivityResult>>? _connectivitySubscription;
+
   /// Checks if the [Uri] specified in [option] is reachable.
   ///
   /// Returns a [Future] that completes with an [InternetCheckResult] indicating
   /// whether the host is reachable or not.
-  Future<InternetCheckResult> _checkReachabilityFor(
-    InternetCheckOption option,
-  ) async {
+  Future<InternetCheckResult> _checkReachabilityFor(InternetCheckOption option) async {
     try {
-      if (customConnectivityCheck != null) {
-        return customConnectivityCheck!.call(option);
-      }
-
-      final response = await http
-          .head(option.uri, headers: option.headers)
-          .timeout(option.timeout);
+      if (customConnectivityCheck != null) return customConnectivityCheck!(option);
+      final response = await http.head(option.uri, headers: option.headers).timeout(option.timeout);
 
       return InternetCheckResult(
         option: option,
@@ -206,64 +202,57 @@ class InternetConnection {
   ///
   /// Returns a [Future] that completes with a boolean value indicating
   /// whether internet access is available or not.
-  Future<bool> get hasInternetAccess async {
-    final completer = Completer<bool>();
-    int remainingChecks = _internetCheckOptions.length;
-    int successCount = 0;
+  /// Checks if there is internet access by verifying connectivity to the
+  /// specified [Uri]s.
+  Future<bool> get hasInternetAccess =>
+      enableStrictCheck ? _hasInternetAccessStrict() : _hasInternetAccessNonStrict();
 
-    for (final option in _internetCheckOptions) {
-      unawaited(
-        _checkReachabilityFor(option).then((result) {
-          if (result.isSuccess) {
-            successCount += 1;
-          }
+  /// Checks internet access in strict mode (all endpoints must succeed)
+  Future<bool> _hasInternetAccessStrict() async {
+    final results = await Future.wait(
+      _internetCheckOptions.map(_checkReachabilityFor),
+    );
 
-          remainingChecks -= 1;
+    return results.every((result) => result.isSuccess);
+  }
 
-          if (completer.isCompleted) return;
+  /// Checks internet access in non-strict mode (at least one endpoint must succeed)
+  Future<bool> _hasInternetAccessNonStrict() async {
+    final futures = _internetCheckOptions.map(_checkReachabilityFor);
 
-          if (!enableStrictCheck && result.isSuccess) {
-            // Return true immediately if not in strict mode and a success is found.
-            completer.complete(true);
-          } else if (enableStrictCheck && remainingChecks == 0) {
-            // In strict mode, complete only when all checks are done.
-            completer.complete(successCount == _internetCheckOptions.length);
-          } else if (!enableStrictCheck && remainingChecks == 0) {
-            // In non-strict mode, complete as false if no success is found.
-            completer.complete(false);
-          }
-        }),
-      );
+    for (final future in futures) {
+      try {
+        final result = await future;
+        if (result.isSuccess) return true;
+      } catch (_) {
+        // Continue checking other endpoints
+        continue;
+      }
     }
 
-    return completer.future;
+    return false;
   }
 
   /// Returns the current internet connection status.
   ///
   /// Returns a [Future] that completes with the [InternetStatus] indicating
   /// the current internet connection status.
-  Future<InternetStatus> get internetStatus async => await hasInternetAccess
-      ? InternetStatus.connected
-      : InternetStatus.disconnected;
+  Future<InternetStatus> get internetStatus async =>
+      await hasInternetAccess ? InternetStatus.connected : InternetStatus.disconnected;
 
   /// Internal method for emitting status updates.
   ///
   /// Updates the status and emits it if there are listeners.
   Future<void> _maybeEmitStatusUpdate() async {
+    if (!_statusController.hasListener) return;
+
     _startListeningToConnectivityChanges();
     _timerHandle?.cancel();
 
     final currentStatus = await internetStatus;
-
-    if (!_statusController.hasListener) return;
-
-    if (_lastStatus != currentStatus && _statusController.hasListener) {
-      _statusController.add(currentStatus);
-    }
+    if (_lastStatus != currentStatus) _statusController.add(currentStatus);
 
     _timerHandle = Timer(_checkInterval, _maybeEmitStatusUpdate);
-
     _lastStatus = currentStatus;
   }
 
@@ -287,20 +276,16 @@ class InternetConnection {
   /// Stream that emits internet connection status changes.
   Stream<InternetStatus> get onStatusChange => _statusController.stream;
 
-  /// Connectivity subscription.
-  StreamSubscription<List<ConnectivityResult>>? _connectivitySubscription;
-
   /// Starts listening to connectivity changes from [connectivity_plus] package
   /// using the [Connectivity.onConnectivityChanged] stream.
   ///
   /// [connectivity_plus]: https://pub.dev/packages/connectivity_plus
   void _startListeningToConnectivityChanges() {
     if (_connectivitySubscription != null) return;
+
     _connectivitySubscription = Connectivity().onConnectivityChanged.listen(
       (_) {
-        if (_statusController.hasListener) {
-          _maybeEmitStatusUpdate();
-        }
+        if (_statusController.hasListener) _maybeEmitStatusUpdate();
       },
       onError: (_, __) {},
     );


### PR DESCRIPTION
I made some improvements:

1. Simplified hasInternetAccess logic
    - Split into two separate methods _hasInternetAccessStrict and _hasInternetAccessNonStrict
    - Removed complex completer logic and race conditions
    - Used Future.wait for strict mode and sequential checking for non-strict mode
2. Cleaned up _maybeEmitStatusUpdate
    - Moved early return to the top for better readability
    - Removed duplicate listener checks
    - Made the control flow more linear
3. Simplified _handleStatusChangeCancel
    - Removed unnecessary then callback for subscription cancellation
    - Made the method more straightforward
4. Improved `_checkReachabilityFor`:  use null assertion operator for cleaner code
5. Better error handling in `_hasInternetAccessNonStrict`: added try-catch to handle individual endpoint failures gracefully

I did this in the context to be better be able to support the new feature request in https://github.com/OutdatedGuy/internet_connection_checker_plus/issues/71