### PR TITLE
[#71] 🐌 Slow connection detection

### DIFF
--- a/lib/internet_connection_checker_plus.dart
+++ b/lib/internet_connection_checker_plus.dart
@@ -71,3 +71,4 @@ part 'src/internet_check_option.dart';
 part 'src/internet_check_result.dart';
 part 'src/internet_connection.dart';
 part 'src/internet_status.dart';
+part 'src/slow_connection_config.dart';

--- a/lib/src/internet_check_result.dart
+++ b/lib/src/internet_check_result.dart
@@ -14,6 +14,7 @@ class InternetCheckResult {
   InternetCheckResult({
     required this.option,
     required this.isSuccess,
+    this.responseTime,
   });
 
   /// The option used to check internet connection for this result.
@@ -25,11 +26,16 @@ class InternetCheckResult {
   /// Otherwise, it was unsuccessful.
   final bool isSuccess;
 
+  /// The time it took to get the response.
+  /// This will be null for custom connectivity checks.
+  final Duration? responseTime;
+
   @override
   String toString() {
     return 'InternetCheckResult(\n'
         '  option: ${option.toString().replaceAll('\n', '\n  ')},\n'
         '  isSuccess: $isSuccess\n'
+        '  responseTime: $responseTime\n'
         ')';
   }
 }

--- a/lib/src/internet_connection.dart
+++ b/lib/src/internet_connection.dart
@@ -162,21 +162,17 @@ class InternetConnection {
   /// The handle for the timer used for periodic status checks.
   Timer? _timerHandle;
 
+  /// Connectivity subscription.
+  StreamSubscription<List<ConnectivityResult>>? _connectivitySubscription;
+
   /// Checks if the [Uri] specified in [option] is reachable.
   ///
   /// Returns a [Future] that completes with an [InternetCheckResult] indicating
   /// whether the host is reachable or not.
-  Future<InternetCheckResult> _checkReachabilityFor(
-    InternetCheckOption option,
-  ) async {
+  Future<InternetCheckResult> _checkReachabilityFor(InternetCheckOption option) async {
     try {
-      if (customConnectivityCheck != null) {
-        return customConnectivityCheck!.call(option);
-      }
-
-      final response = await http
-          .head(option.uri, headers: option.headers)
-          .timeout(option.timeout);
+      if (customConnectivityCheck != null) return customConnectivityCheck!(option);
+      final response = await http.head(option.uri, headers: option.headers).timeout(option.timeout);
 
       return InternetCheckResult(
         option: option,
@@ -206,64 +202,57 @@ class InternetConnection {
   ///
   /// Returns a [Future] that completes with a boolean value indicating
   /// whether internet access is available or not.
-  Future<bool> get hasInternetAccess async {
-    final completer = Completer<bool>();
-    int remainingChecks = _internetCheckOptions.length;
-    int successCount = 0;
+  /// Checks if there is internet access by verifying connectivity to the
+  /// specified [Uri]s.
+  Future<bool> get hasInternetAccess =>
+      enableStrictCheck ? _hasInternetAccessStrict() : _hasInternetAccessNonStrict();
 
-    for (final option in _internetCheckOptions) {
-      unawaited(
-        _checkReachabilityFor(option).then((result) {
-          if (result.isSuccess) {
-            successCount += 1;
-          }
+  /// Checks internet access in strict mode (all endpoints must succeed)
+  Future<bool> _hasInternetAccessStrict() async {
+    final results = await Future.wait(
+      _internetCheckOptions.map(_checkReachabilityFor),
+    );
 
-          remainingChecks -= 1;
+    return results.every((result) => result.isSuccess);
+  }
 
-          if (completer.isCompleted) return;
+  /// Checks internet access in non-strict mode (at least one endpoint must succeed)
+  Future<bool> _hasInternetAccessNonStrict() async {
+    final futures = _internetCheckOptions.map(_checkReachabilityFor);
 
-          if (!enableStrictCheck && result.isSuccess) {
-            // Return true immediately if not in strict mode and a success is found.
-            completer.complete(true);
-          } else if (enableStrictCheck && remainingChecks == 0) {
-            // In strict mode, complete only when all checks are done.
-            completer.complete(successCount == _internetCheckOptions.length);
-          } else if (!enableStrictCheck && remainingChecks == 0) {
-            // In non-strict mode, complete as false if no success is found.
-            completer.complete(false);
-          }
-        }),
-      );
+    for (final future in futures) {
+      try {
+        final result = await future;
+        if (result.isSuccess) return true;
+      } catch (_) {
+        // Continue checking other endpoints
+        continue;
+      }
     }
 
-    return completer.future;
+    return false;
   }
 
   /// Returns the current internet connection status.
   ///
   /// Returns a [Future] that completes with the [InternetStatus] indicating
   /// the current internet connection status.
-  Future<InternetStatus> get internetStatus async => await hasInternetAccess
-      ? InternetStatus.connected
-      : InternetStatus.disconnected;
+  Future<InternetStatus> get internetStatus async =>
+      await hasInternetAccess ? InternetStatus.connected : InternetStatus.disconnected;
 
   /// Internal method for emitting status updates.
   ///
   /// Updates the status and emits it if there are listeners.
   Future<void> _maybeEmitStatusUpdate() async {
+    if (!_statusController.hasListener) return;
+
     _startListeningToConnectivityChanges();
     _timerHandle?.cancel();
 
     final currentStatus = await internetStatus;
-
-    if (!_statusController.hasListener) return;
-
-    if (_lastStatus != currentStatus && _statusController.hasListener) {
-      _statusController.add(currentStatus);
-    }
+    if (_lastStatus != currentStatus) _statusController.add(currentStatus);
 
     _timerHandle = Timer(_checkInterval, _maybeEmitStatusUpdate);
-
     _lastStatus = currentStatus;
   }
 
@@ -273,9 +262,8 @@ class InternetConnection {
   void _handleStatusChangeCancel() {
     if (_statusController.hasListener) return;
 
-    _connectivitySubscription?.cancel().then((_) {
-      _connectivitySubscription = null;
-    });
+    _connectivitySubscription?.cancel();
+    _connectivitySubscription = null;
     _timerHandle?.cancel();
     _timerHandle = null;
     _lastStatus = null;
@@ -287,20 +275,16 @@ class InternetConnection {
   /// Stream that emits internet connection status changes.
   Stream<InternetStatus> get onStatusChange => _statusController.stream;
 
-  /// Connectivity subscription.
-  StreamSubscription<List<ConnectivityResult>>? _connectivitySubscription;
-
   /// Starts listening to connectivity changes from [connectivity_plus] package
   /// using the [Connectivity.onConnectivityChanged] stream.
   ///
   /// [connectivity_plus]: https://pub.dev/packages/connectivity_plus
   void _startListeningToConnectivityChanges() {
     if (_connectivitySubscription != null) return;
+
     _connectivitySubscription = Connectivity().onConnectivityChanged.listen(
       (_) {
-        if (_statusController.hasListener) {
-          _maybeEmitStatusUpdate();
-        }
+        if (_statusController.hasListener) _maybeEmitStatusUpdate();
       },
       onError: (_, __) {},
     );

--- a/lib/src/internet_status.dart
+++ b/lib/src/internet_status.dart
@@ -18,6 +18,9 @@ enum InternetStatus {
   /// Internet is available because at least one of the HEAD requests succeeded.
   connected,
 
+  /// Internet is available but the connection is slow.
+  slow,
+
   /// None of the HEAD requests succeeded. Basically, no internet.
   disconnected,
 }

--- a/lib/src/slow_connection_config.dart
+++ b/lib/src/slow_connection_config.dart
@@ -1,0 +1,26 @@
+part of '../internet_connection_checker_plus.dart';
+
+/// Configuration options for detecting slow internet connections.
+///
+/// The [SlowConnectionConfig] class allows you to specify settings for detecting slow internet connections.
+/// This includes whether to enable slow connection detection and the threshold duration that defines a "slow" connection.
+/// *Example Usage:*
+/// ```dart
+/// final config = SlowConnectionConfig(slowConnectionThreshold: Duration(seconds: 5));
+/// ```
+class SlowConnectionConfig {
+  /// The threshold duration that defines a "slow" connection.
+  ///
+  /// A connection is considered slow if the response time
+  /// exceeds this duration.
+  final Duration slowConnectionThreshold;
+
+  /// Creates an instance of `SlowConnectionConfig`.
+  /// The [slowConnectionThreshold] parameter defines the threshold duration
+  ///
+  /// *Example:*
+  /// ```dart
+  /// final config = SlowConnectionConfig(slowConnectionThreshold: Duration(seconds: 5));
+  /// ```
+  const SlowConnectionConfig({required this.slowConnectionThreshold});
+}

--- a/test/internet_check_result_test.dart
+++ b/test/internet_check_result_test.dart
@@ -1,6 +1,5 @@
 // Flutter Packages
 import 'package:flutter_test/flutter_test.dart';
-
 // This Package
 import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart';
 
@@ -23,6 +22,7 @@ void main() {
           '    headers: {}\n'
           '  ),\n'
           '  isSuccess: true\n'
+          '  responseTime: null\n'
           ')';
 
       expect(result.toString(), expectedString);


### PR DESCRIPTION
This builds on https://github.com/OutdatedGuy/internet_connection_checker_plus/pull/118 to implement https://github.com/OutdatedGuy/internet_connection_checker_plus/issues/71.

## Summary of changes
1. Added `SlowConnectionConfig` class
    - Use to configure the 'what is slow'
2.  Updated InternetCheckResult to include `responseTime` field
    - Will be used to track the timing of the response of the result
3. Implementation in `InternetConnection`
    - Modified `_checkReachabilityFor` to measure and record response time
    - Updated `internetStatus` getter to check for slow connections when config is provided
    - Added two new methods for slow detection in both strict and non-strict modes
        1. `_internetStatusWithSlowDetectionStrict()`: Checks if all endpoints are successful, then checks if any are slow
        2. `_internetStatusWithSlowDetectionNonStrict()`: Checks for any successful endpoint, returns connected if fast connection found, slow if only slow connections found

## Summary of behaviour
This makes the final behaviour as follows
- When slowConnectionConfig is null: Behaves as before with just connected/disconnected
- When slowConnectionConfig is provided
    - In strict mode: All endpoints must succeed. If any successful response exceeds the threshold, status is slow
    - In non-strict mode: Returns connected as soon as a fast connection is found, slow if only slow connections found, disconnected if none succeed
    - hasInternetAccess still returns true for both connected and slow statuses

## Left to do
1. Add new unit tests for the slow detection