### PR TITLE
v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 3.0.0
+
+Please read the [v3 Migration Guide](MIGRATION_V3.md) for details on updating your project.
+
+### Breaking Changes
+
+- feat!: remove dependency on connectivity_plus in [c09b432](https://github.com/OutdatedGuy/internet_connection_checker_plus/commit/c09b432)
+
+### Other Changes
+
+- feat: update library to a Dart package in [4267811](https://github.com/OutdatedGuy/internet_connection_checker_plus/commit/4267811)
+- feat: update default endpoints to more robust ones in [78c54ab](https://github.com/OutdatedGuy/internet_connection_checker_plus/commit/78c54ab)
+- fix: 2nd and later listeners never get internet status in [2313d04](https://github.com/OutdatedGuy/internet_connection_checker_plus/commit/2313d04)
+- docs: revamp readme for cleaner documentation in [dc47714](https://github.com/OutdatedGuy/internet_connection_checker_plus/commit/dc47714)
+- chore: updated example app to Flutter v3.41.7 in [fd3c5e6](https://github.com/OutdatedGuy/internet_connection_checker_plus/commit/fd3c5e6)
+
 ## 2.9.1+2
 
 - docs: fix lifecycle changes code example in [222ef0b](https://github.com/OutdatedGuy/internet_connection_checker_plus/commit/222ef0b)
@@ -101,12 +117,10 @@
 ## 1.0.0
 
 - **BREAKING CHANGES**
-
   - Using `http` requests instead of `Socket` connections.
   - Replaced `InternetAddress` with `Uri`.
 
 - **NEW FEATURES**
-
   - Added **_proper_** `Web` support.
   - Faster connection checks.
   - Reduced latency.

--- a/MIGRATION_V3.md
+++ b/MIGRATION_V3.md
@@ -1,0 +1,56 @@
+# Migration Guide: v2 to v3
+
+This major release removed the dependency on the
+[`connectivity_plus`](https://pub.dev/packages/connectivity_plus) package,
+converting this library into a pure Dart package. If your application relied on
+hardware network connectivity changes to quickly trigger internet reachability
+checks, you must now pass a trigger stream explicitly.
+
+## Breaking Changes
+
+- Automatic listening to network hardware changes (e.g. Wi-Fi turning off) is no
+  longer enabled by default since we no longer depend on `connectivity_plus`.
+
+## Migration Steps
+
+If you want to maintain the exact same behavior from `v2.x.x`, follow these
+steps:
+
+### 1. Add `connectivity_plus` to your pubspec.yaml
+
+Since it is no longer bundled with our package, you must install it directly.
+
+```yaml
+dependencies:
+  internet_connection_checker_plus: ^3.0.0
+  connectivity_plus: ^7.0.0 # or latest
+```
+
+### 2. Pass the trigger stream to `InternetConnection`
+
+When you create or configure the internet connection, use the `createInstance`
+method and pass `Connectivity().onConnectivityChanged` to the new
+`triggerStream` parameter.
+
+**Before (v2):**
+
+```dart
+import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart';
+
+final connection = InternetConnection();
+```
+
+**After (v3):**
+
+```dart
+import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+final connection = InternetConnection.createInstance(
+  triggerStream: Connectivity().onConnectivityChanged,
+);
+```
+
+By providing a `triggerStream`, `InternetConnection` will instantly execute a
+ping reachability check whenever `connectivity_plus` emits an event, ensuring
+your users get the most accurate and real-time connectivity status.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ connectivity) but cannot guarantee actual internet reachability. This package
 proactively verifies external routing by checking reachability and response
 statuses against highly available global endpoints.
 
+> [!WARNING]
+>
+> **🚀 v3 is now available!** Which removed the `connectivity_plus` dependency
+> to make this a pure Dart package. Please read the
+> [v3 Migration Guide](MIGRATION_V3.md) to understand the breaking changes and
+> how to update your project.
+
 ## Features
 
 - **Accurate Verification:** Verifies real internet access instead of local

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ connectivity) but cannot guarantee actual internet reachability. This package
 proactively verifies external routing by checking reachability and response
 statuses against highly available global endpoints.
 
-> [!WARNING]
+> [!NOTE]
 >
-> **🚀 v3 is now available!** Which removed the `connectivity_plus` dependency
-> to make this a pure Dart package. Please read the
+> **🚀 v3 is now available!** It removes the `connectivity_plus` dependency to
+> make this a pure Dart package. Please read the
 > [v3 Migration Guide](MIGRATION_V3.md) to understand the breaking changes and
 > how to update your project.
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -129,7 +129,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.9.1+2"
+    version: "3.0.0"
   lints:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: internet_connection_checker_plus
 description: A pure Dart package to check your internet connection with subsecond response times, even on mobile networks!
-version: 2.9.1+2
+version: 3.0.0
 homepage: https://outdatedguy.rocks
 repository: https://github.com/OutdatedGuy/internet_connection_checker_plus
 topics:


### PR DESCRIPTION
## What's Changed
* test: add custom check options for strict internet access validation by @OutdatedGuy in https://github.com/OutdatedGuy/internet_connection_checker_plus/pull/117
* chore: updated example app to Flutter v3.41.7 by @OutdatedGuy in https://github.com/OutdatedGuy/internet_connection_checker_plus/pull/123
* feat!: remove dependency on connectivity_plus by @OutdatedGuy in https://github.com/OutdatedGuy/internet_connection_checker_plus/pull/124
* feat: update default endpoints to more robust ones by @OutdatedGuy in https://github.com/OutdatedGuy/internet_connection_checker_plus/pull/125
* refactor: streamline status update logic and event handling by @OutdatedGuy in https://github.com/OutdatedGuy/internet_connection_checker_plus/pull/126
* fix: 2nd and later listeners never get internet status by @OutdatedGuy in https://github.com/OutdatedGuy/internet_connection_checker_plus/pull/127
* feat: update library to a Dart package by @OutdatedGuy in https://github.com/OutdatedGuy/internet_connection_checker_plus/pull/128
* docs: revamp readme for cleaner documentation by @OutdatedGuy in https://github.com/OutdatedGuy/internet_connection_checker_plus/pull/129