### PR TITLE
feat: Add optional exponential backoff for polling interval (#99)

### DIFF
--- a/lib/internet_connection_checker_plus.dart
+++ b/lib/internet_connection_checker_plus.dart
@@ -60,7 +60,9 @@ library internet_connection_checker_plus;
 import 'dart:async';
 
 import 'package:http/http.dart' as http;
+import 'package:meta/meta.dart';
 
+part 'src/exponential_backoff_options.dart';
 part 'src/internet_check_option.dart';
 part 'src/internet_check_result.dart';
 part 'src/internet_connection.dart';

--- a/lib/src/exponential_backoff_options.dart
+++ b/lib/src/exponential_backoff_options.dart
@@ -1,0 +1,113 @@
+part of '../internet_connection_checker_plus.dart';
+
+/// Configuration for exponential backoff of the polling interval used by
+/// [InternetConnection.onStatusChange].
+///
+/// Pass an instance to [InternetConnection.createInstance]'s `backoffOptions`
+/// parameter to enable it. When omitted (`null`), the polling interval stays
+/// fixed at [InternetConnection.checkInterval], preserving the existing
+/// behaviour exactly.
+///
+/// *Usage Example:*
+///
+/// ```dart
+/// final checker = InternetConnection.createInstance(
+///   backoffOptions: ExponentialBackoffOptions(
+///     maxDelay: Duration(seconds: 60),
+///     multiplier: 2.0,
+///   ),
+/// );
+/// ```
+@immutable
+class ExponentialBackoffOptions {
+  /// Creates an [ExponentialBackoffOptions] instance.
+  ///
+  /// The [initialDelay] is the delay applied after the first detected
+  /// failure. If omitted, it tracks
+  /// [InternetConnection.checkInterval] instead, including through
+  /// [InternetConnection.setIntervalAndResetTimer] calls.
+  ///
+  /// The [maxDelay] caps how large the delay may grow. Defaults to 60
+  /// seconds.
+  ///
+  /// The [multiplier] is the factor applied to the delay on each consecutive
+  /// failure. Defaults to `2.0`.
+  ExponentialBackoffOptions({
+    this.initialDelay,
+    this.maxDelay = const Duration(seconds: 60),
+    this.multiplier = 2.0,
+  })  : assert(
+          multiplier.isFinite && multiplier >= 1.0,
+          'multiplier must be a finite number >= 1.0, to prevent shrinking '
+          'or invalid intervals.',
+        ),
+        assert(maxDelay > Duration.zero, 'maxDelay must be greater than zero.'),
+        assert(
+          initialDelay == null || initialDelay > Duration.zero,
+          'initialDelay must be greater than zero.',
+        ),
+        assert(
+          initialDelay == null || initialDelay <= maxDelay,
+          'initialDelay must be less than or equal to maxDelay.',
+        );
+
+  /// The delay applied after the first detected failure.
+  ///
+  /// If `null`, tracks [InternetConnection.checkInterval] instead.
+  final Duration? initialDelay;
+
+  /// The upper bound on the backoff delay.
+  ///
+  /// Defaults to 60 seconds.
+  final Duration maxDelay;
+
+  /// The factor applied to the delay on each consecutive failure.
+  ///
+  /// Defaults to `2.0`.
+  final double multiplier;
+
+  /// Resolves the delay to use on the first failure, falling back to
+  /// [checkInterval] when [initialDelay] was not provided.
+  Duration resolveInitialDelay(Duration checkInterval) {
+    final delay = initialDelay ?? checkInterval;
+    return delay > maxDelay ? maxDelay : delay;
+  }
+
+  /// Computes the delay to use before the next poll.
+  ///
+  /// Pass [isFirstFailure] as `true` for the first failure in a new streak
+  /// (i.e. the previous poll succeeded, or backoff was just reset), and
+  /// `false` for an ongoing failure streak, in which case [current] is grown
+  /// by [multiplier] and capped at [maxDelay].
+  Duration nextDelay({
+    required Duration current,
+    required bool isFirstFailure,
+    required Duration checkInterval,
+  }) {
+    if (isFirstFailure) return resolveInitialDelay(checkInterval);
+
+    final grownMs = (current.inMilliseconds * multiplier).round();
+    return Duration(
+      milliseconds: grownMs.clamp(0, maxDelay.inMilliseconds).toInt(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ExponentialBackoffOptions &&
+          runtimeType == other.runtimeType &&
+          initialDelay == other.initialDelay &&
+          maxDelay == other.maxDelay &&
+          multiplier == other.multiplier;
+
+  @override
+  int get hashCode => Object.hash(initialDelay, maxDelay, multiplier);
+
+  @override
+  String toString() => 'ExponentialBackoffOptions(\n'
+      '  initialDelay: $initialDelay,\n'
+      '  maxDelay: $maxDelay,\n'
+      '  multiplier: $multiplier\n'
+      ')';
+}

--- a/lib/src/internet_connection.dart
+++ b/lib/src/internet_connection.dart
@@ -211,6 +211,9 @@ class InternetConnection {
   /// Defaults to 2.0.
   final double _backoffMultiplier;
 
+  /// Whether the backoff state was forcefully reset by an interval change.
+  bool _backoffNeedsReset = false;
+
   /// The live backoff delay, updated each polling cycle when backoff is enabled.
   ///
   /// Resets to [_backoffInitialDelay] on reconnect or subscription cancel.
@@ -259,6 +262,7 @@ class InternetConnection {
       // caller never provided an explicit backoffInitialDelay.
       if (!_backoffInitialDelayExplicit) _backoffInitialDelay = duration;
       _currentBackoffDelay = _backoffInitialDelay;
+      _backoffNeedsReset = true;
     }
     _timerHandle?.cancel();
     _timerHandle = Timer(_checkInterval, _maybeEmitStatusUpdate);
@@ -337,9 +341,12 @@ class InternetConnection {
       if (currentStatus == InternetStatus.connected) {
         _currentBackoffDelay = _backoffInitialDelay;
         nextDelay = _checkInterval;
-      } else if (previousStatus != InternetStatus.disconnected) {
+      } else if (previousStatus != InternetStatus.disconnected || _backoffNeedsReset) {
         // First failure: previousStatus is either null (first ever poll) or
         // connected — both mean we have not yet been in a backoff streak.
+        // Also, if _backoffNeedsReset is true, we treat this as a first failure to
+        // reset the backoff delay, even if the previous status was already disconnected.
+        _backoffNeedsReset = false;
         _currentBackoffDelay = _backoffInitialDelay;
         nextDelay = _currentBackoffDelay;
       } else {
@@ -368,6 +375,7 @@ class InternetConnection {
     _timerHandle?.cancel();
     _timerHandle = null;
     _lastStatus = null;
+    _backoffNeedsReset = false;
     if (useExponentialBackoff) _currentBackoffDelay = _backoffInitialDelay;
   }
 

--- a/lib/src/internet_connection.dart
+++ b/lib/src/internet_connection.dart
@@ -359,7 +359,9 @@ class InternetConnection {
         // Also, if _backoffNeedsReset is true, we treat this as a first failure to
         // reset the backoff delay, even if the previous status was already disconnected.
         _backoffNeedsReset = false;
-        _currentBackoffDelay = _backoffInitialDelay;
+        _currentBackoffDelay = _backoffInitialDelay > _backoffMaxDelay
+            ? _backoffMaxDelay
+            : _backoffInitialDelay;
         nextDelay = _currentBackoffDelay;
       } else {
         // Ongoing failure: grow the delay.

--- a/lib/src/internet_connection.dart
+++ b/lib/src/internet_connection.dart
@@ -114,6 +114,18 @@ class InternetConnection {
         assert(
           !useExponentialBackoff || backoffMaxDelay > Duration.zero,
           'backoffMaxDelay must be greater than zero.',
+        ), 
+        assert(
+          !useExponentialBackoff ||
+              (backoffInitialDelay ?? checkInterval ?? _defaultCheckInterval) >
+                  Duration.zero,
+          'backoffInitialDelay (or checkInterval if implicitly used) must be greater than zero.',
+        ),
+        assert(
+          !useExponentialBackoff ||
+              (backoffInitialDelay ?? checkInterval ?? _defaultCheckInterval) <=
+                  backoffMaxDelay,
+          'backoffInitialDelay (or checkInterval if implicitly used) must be less than or equal to backoffMaxDelay.',
         ) {
     _internetCheckOptions = List.unmodifiable([
       if (useDefaultOptions) ..._defaultCheckOptions,

--- a/lib/src/internet_connection.dart
+++ b/lib/src/internet_connection.dart
@@ -246,6 +246,16 @@ class InternetConnection {
   /// The handle for the timer used for periodic status checks.
   Timer? _timerHandle;
 
+  /// Monotonically increasing counter bumped whenever an in-flight
+  /// [_maybeEmitStatusUpdate] must be invalidated: on [setIntervalAndResetTimer]
+  /// and on [_handleStatusChangeCancel].
+  ///
+  /// Each [_maybeEmitStatusUpdate] invocation captures this value on entry.
+  /// Before mutating shared backoff state or scheduling the next timer it
+  /// checks that the value has not changed.  A mismatch means this invocation
+  /// is stale — another caller already rescheduled and owns the next cycle.
+  int _generation = 0;
+
   /// Checks if the [Uri] specified in [option] is reachable.
   ///
   /// Returns a [Future] that completes with an [InternetCheckResult] indicating
@@ -285,6 +295,7 @@ class InternetConnection {
       _currentBackoffDelay = _backoffInitialDelay;
       _backoffNeedsReset = true;
     }
+    _generation++;
     _timerHandle?.cancel();
     _timerHandle = Timer(_checkInterval, _maybeEmitStatusUpdate);
   }
@@ -343,6 +354,7 @@ class InternetConnection {
   /// Updates the status and emits it if there are listeners.
   Future<void> _maybeEmitStatusUpdate() async {
     _timerHandle?.cancel();
+    final generation = _generation;
 
     if (!_statusController.hasListener) return;
 
@@ -356,6 +368,14 @@ class InternetConnection {
       _lastStatus = currentStatus;
       _statusController.add(currentStatus);
     }
+
+    if (!_statusController.hasListener) return;
+    // Guard before mutating shared backoff state: a setIntervalAndResetTimer
+    // call that arrived while we were awaiting internetStatus has already
+    // bumped _generation and scheduled its own timer.  Mutating
+    // _currentBackoffDelay / _backoffNeedsReset here would silently overwrite
+    // the reset that setIntervalAndResetTimer applied.
+    if (_generation != generation) return;
 
     Duration nextDelay;
     if (useExponentialBackoff) {
@@ -386,7 +406,6 @@ class InternetConnection {
       nextDelay = _checkInterval;
     }
 
-    if (!_statusController.hasListener) return;
     _timerHandle = Timer(nextDelay, _maybeEmitStatusUpdate);
   }
 
@@ -396,6 +415,7 @@ class InternetConnection {
   void _handleStatusChangeCancel() {
     _triggerSubscription?.cancel();
     _triggerSubscription = null;
+    _generation++;
     _timerHandle?.cancel();
     _timerHandle = null;
     _lastStatus = null;

--- a/lib/src/internet_connection.dart
+++ b/lib/src/internet_connection.dart
@@ -114,7 +114,7 @@ class InternetConnection {
         assert(
           !useExponentialBackoff || backoffMaxDelay > Duration.zero,
           'backoffMaxDelay must be greater than zero.',
-        ), 
+        ),
         assert(
           !useExponentialBackoff ||
               (backoffInitialDelay ?? checkInterval ?? _defaultCheckInterval) >
@@ -353,7 +353,8 @@ class InternetConnection {
       if (currentStatus == InternetStatus.connected) {
         _currentBackoffDelay = _backoffInitialDelay;
         nextDelay = _checkInterval;
-      } else if (previousStatus != InternetStatus.disconnected || _backoffNeedsReset) {
+      } else if (previousStatus != InternetStatus.disconnected ||
+          _backoffNeedsReset) {
         // First failure: previousStatus is either null (first ever poll) or
         // connected — both mean we have not yet been in a backoff streak.
         // Also, if _backoffNeedsReset is true, we treat this as a first failure to
@@ -368,8 +369,7 @@ class InternetConnection {
         final ms =
             (_currentBackoffDelay.inMilliseconds * _backoffMultiplier).round();
         _currentBackoffDelay = Duration(
-          milliseconds:
-              ms.clamp(0, _backoffMaxDelay.inMilliseconds).toInt(),
+          milliseconds: ms.clamp(0, _backoffMaxDelay.inMilliseconds).toInt(),
         );
         nextDelay = _currentBackoffDelay;
       }

--- a/lib/src/internet_connection.dart
+++ b/lib/src/internet_connection.dart
@@ -90,11 +90,30 @@ class InternetConnection {
     this.enableStrictCheck = false,
     this.customConnectivityCheck,
     this.triggerStream,
+    this.useExponentialBackoff = false,
+    Duration? backoffInitialDelay,
+    Duration backoffMaxDelay = const Duration(seconds: 60),
+    double backoffMultiplier = 2.0,
   })  : _checkInterval = checkInterval ?? _defaultCheckInterval,
+        _backoffInitialDelayExplicit = backoffInitialDelay != null,
+        _backoffInitialDelay =
+            backoffInitialDelay ?? checkInterval ?? _defaultCheckInterval,
+        _backoffMaxDelay = backoffMaxDelay,
+        _backoffMultiplier = backoffMultiplier,
+        _currentBackoffDelay =
+            backoffInitialDelay ?? checkInterval ?? _defaultCheckInterval,
         assert(
           useDefaultOptions || customCheckOptions?.isNotEmpty == true,
           'You must provide a list of options if you are not using the '
           'default ones.',
+        ),
+        assert(
+          !useExponentialBackoff || backoffMultiplier > 0,
+          'backoffMultiplier must be positive.',
+        ),
+        assert(
+          !useExponentialBackoff || backoffMaxDelay > Duration.zero,
+          'backoffMaxDelay must be greater than zero.',
         ) {
     _internetCheckOptions = List.unmodifiable([
       if (useDefaultOptions) ..._defaultCheckOptions,
@@ -162,6 +181,41 @@ class InternetConnection {
   /// whenever it emits an event.
   final Stream? triggerStream;
 
+  /// Whether exponential backoff is enabled for the polling interval.
+  ///
+  /// When `true`, the polling interval grows on consecutive failures and resets
+  /// to [checkInterval] when the connection is restored.
+  ///
+  /// Defaults to `false`.
+  final bool useExponentialBackoff;
+
+  /// Whether [_backoffInitialDelay] was explicitly provided by the caller.
+  ///
+  /// When `false`, [_backoffInitialDelay] tracks [_checkInterval] so that
+  /// a [setIntervalAndResetTimer] call keeps both values in sync.
+  final bool _backoffInitialDelayExplicit;
+
+  /// The initial delay used on the first failure when backoff is enabled.
+  ///
+  /// Defaults to [checkInterval]. Updated by [setIntervalAndResetTimer] when
+  /// no explicit value was provided at construction time.
+  Duration _backoffInitialDelay;
+
+  /// The upper bound on the backoff delay.
+  ///
+  /// Defaults to 60 seconds.
+  final Duration _backoffMaxDelay;
+
+  /// The multiplicative factor applied to the delay on each consecutive failure.
+  ///
+  /// Defaults to 2.0.
+  final double _backoffMultiplier;
+
+  /// The live backoff delay, updated each polling cycle when backoff is enabled.
+  ///
+  /// Resets to [_backoffInitialDelay] on reconnect or subscription cancel.
+  Duration _currentBackoffDelay;
+
   /// The last known internet connection status result.
   InternetStatus? _lastStatus;
 
@@ -200,6 +254,12 @@ class InternetConnection {
   /// resets the connection checking timer.
   void setIntervalAndResetTimer(Duration duration) {
     _checkInterval = duration;
+    if (useExponentialBackoff) {
+      // Keep _backoffInitialDelay in sync with the new checkInterval when the
+      // caller never provided an explicit backoffInitialDelay.
+      if (!_backoffInitialDelayExplicit) _backoffInitialDelay = duration;
+      _currentBackoffDelay = _backoffInitialDelay;
+    }
     _timerHandle?.cancel();
     _timerHandle = Timer(_checkInterval, _maybeEmitStatusUpdate);
   }
@@ -261,6 +321,10 @@ class InternetConnection {
 
     if (!_statusController.hasListener) return;
 
+    // Snapshot before possible mutation below — needed to detect first-failure
+    // vs. ongoing-failure for backoff calculation.
+    final previousStatus = _lastStatus;
+
     final currentStatus = await internetStatus;
 
     if (_lastStatus != currentStatus && _statusController.hasListener) {
@@ -268,7 +332,31 @@ class InternetConnection {
       _statusController.add(currentStatus);
     }
 
-    _timerHandle = Timer(_checkInterval, _maybeEmitStatusUpdate);
+    Duration nextDelay;
+    if (useExponentialBackoff) {
+      if (currentStatus == InternetStatus.connected) {
+        _currentBackoffDelay = _backoffInitialDelay;
+        nextDelay = _checkInterval;
+      } else if (previousStatus != InternetStatus.disconnected) {
+        // First failure: previousStatus is either null (first ever poll) or
+        // connected — both mean we have not yet been in a backoff streak.
+        _currentBackoffDelay = _backoffInitialDelay;
+        nextDelay = _currentBackoffDelay;
+      } else {
+        // Ongoing failure: grow the delay.
+        final ms =
+            (_currentBackoffDelay.inMilliseconds * _backoffMultiplier).round();
+        _currentBackoffDelay = Duration(
+          milliseconds:
+              ms.clamp(0, _backoffMaxDelay.inMilliseconds).toInt(),
+        );
+        nextDelay = _currentBackoffDelay;
+      }
+    } else {
+      nextDelay = _checkInterval;
+    }
+
+    _timerHandle = Timer(nextDelay, _maybeEmitStatusUpdate);
   }
 
   /// Handles cancellation of status change events.
@@ -280,6 +368,7 @@ class InternetConnection {
     _timerHandle?.cancel();
     _timerHandle = null;
     _lastStatus = null;
+    if (useExponentialBackoff) _currentBackoffDelay = _backoffInitialDelay;
   }
 
   /// The result of the last attempt to check the internet status.

--- a/lib/src/internet_connection.dart
+++ b/lib/src/internet_connection.dart
@@ -97,11 +97,11 @@ class InternetConnection {
   })  : _checkInterval = checkInterval ?? _defaultCheckInterval,
         _backoffInitialDelayExplicit = backoffInitialDelay != null,
         _backoffInitialDelay =
-            backoffInitialDelay ?? checkInterval ?? _defaultCheckInterval,
+            _resolveInitialDelay(backoffInitialDelay, checkInterval),
         _backoffMaxDelay = backoffMaxDelay,
         _backoffMultiplier = backoffMultiplier,
         _currentBackoffDelay =
-            backoffInitialDelay ?? checkInterval ?? _defaultCheckInterval,
+            _resolveInitialDelay(backoffInitialDelay, checkInterval),
         assert(
           useDefaultOptions || customCheckOptions?.isNotEmpty == true,
           'You must provide a list of options if you are not using the '
@@ -124,7 +124,7 @@ class InternetConnection {
       }
       if (_backoffInitialDelay <= Duration.zero) {
         throw ArgumentError.value(
-          backoffInitialDelay,
+          _backoffInitialDelay,
           'backoffInitialDelay',
           'backoffInitialDelay (or checkInterval if implicitly used) must be greater than zero.',
         );
@@ -150,6 +150,12 @@ class InternetConnection {
 
   /// The default check interval duration.
   static const _defaultCheckInterval = Duration(seconds: 10);
+
+  static Duration _resolveInitialDelay(
+    Duration? backoffInitialDelay,
+    Duration? checkInterval,
+  ) =>
+      backoffInitialDelay ?? checkInterval ?? _defaultCheckInterval;
 
   /// The default list of [Uri]s used for checking internet reachability.
   static final _defaultCheckOptions = List<InternetCheckOption>.unmodifiable([

--- a/lib/src/internet_connection.dart
+++ b/lib/src/internet_connection.dart
@@ -377,6 +377,7 @@ class InternetConnection {
       nextDelay = _checkInterval;
     }
 
+    if (!_statusController.hasListener) return;
     _timerHandle = Timer(nextDelay, _maybeEmitStatusUpdate);
   }
 

--- a/lib/src/internet_connection.dart
+++ b/lib/src/internet_connection.dart
@@ -59,7 +59,7 @@ typedef ConnectivityCheckCallback = Future<InternetCheckResult> Function(
 /// will prevent memory leaks and free up resources.
 ///
 /// ```dart
-/// listener.cancel();
+/// await listener.cancel();
 /// ```
 class InternetConnection {
   /// Returns the singleton instance of [InternetConnection].
@@ -262,6 +262,17 @@ class InternetConnection {
   /// is stale — another caller already rescheduled and owns the next cycle.
   int _generation = 0;
 
+  /// Monotonically increasing counter bumped only on [_handleStatusChangeCancel].
+  ///
+  /// Captured before the [await internetStatus] gap and compared before
+  /// emitting.  A mismatch means a cancel+resubscribe cycle happened while
+  /// the check was in-flight: the result belongs to the old subscription context
+  /// and must not be emitted to the new subscriber.
+  ///
+  /// Unlike [_generation], this is NOT bumped by [setIntervalAndResetTimer],
+  /// because interval changes do not affect which subscriber owns the result.
+  int _cancelGeneration = 0;
+
   /// Checks if the [Uri] specified in [option] is reachable.
   ///
   /// Returns a [Future] that completes with an [InternetCheckResult] indicating
@@ -361,6 +372,7 @@ class InternetConnection {
   Future<void> _maybeEmitStatusUpdate() async {
     _timerHandle?.cancel();
     final generation = _generation;
+    final cancelGeneration = _cancelGeneration;
 
     if (!_statusController.hasListener) return;
 
@@ -370,7 +382,12 @@ class InternetConnection {
 
     final currentStatus = await internetStatus;
 
-    if (_lastStatus != currentStatus && _statusController.hasListener) {
+    // Only emit if this result still belongs to the current subscription
+    // context.  A cancel+resubscribe while we were awaiting bumps
+    // _cancelGeneration; the new subscriber owns its own fresh check.
+    if (_cancelGeneration == cancelGeneration &&
+        _lastStatus != currentStatus &&
+        _statusController.hasListener) {
       _lastStatus = currentStatus;
       _statusController.add(currentStatus);
     }
@@ -419,8 +436,12 @@ class InternetConnection {
   ///
   /// Cancels the timer and resets the last status.
   void _handleStatusChangeCancel() {
+    // Not awaited: _handleStatusChangeCancel is a synchronous onCancel
+    // callback.  Any event that fires before cancel propagates will see
+    // hasListener == false and return early from _maybeEmitStatusUpdate.
     _triggerSubscription?.cancel();
     _triggerSubscription = null;
+    _cancelGeneration++;
     _generation++;
     _timerHandle?.cancel();
     _timerHandle = null;

--- a/lib/src/internet_connection.dart
+++ b/lib/src/internet_connection.dart
@@ -108,8 +108,8 @@ class InternetConnection {
           'default ones.',
         ),
         assert(
-          !useExponentialBackoff || backoffMultiplier > 0,
-          'backoffMultiplier must be positive.',
+          !useExponentialBackoff || backoffMultiplier >= 1.0,
+          'backoffMultiplier must be greater than or equal to 1.0 to prevent shrinking intervals.',
         ),
         assert(
           !useExponentialBackoff || backoffMaxDelay > Duration.zero,

--- a/lib/src/internet_connection.dart
+++ b/lib/src/internet_connection.dart
@@ -106,27 +106,36 @@ class InternetConnection {
           useDefaultOptions || customCheckOptions?.isNotEmpty == true,
           'You must provide a list of options if you are not using the '
           'default ones.',
-        ),
-        assert(
-          !useExponentialBackoff || backoffMultiplier >= 1.0,
-          'backoffMultiplier must be greater than or equal to 1.0 to prevent shrinking intervals.',
-        ),
-        assert(
-          !useExponentialBackoff || backoffMaxDelay > Duration.zero,
-          'backoffMaxDelay must be greater than zero.',
-        ),
-        assert(
-          !useExponentialBackoff ||
-              (backoffInitialDelay ?? checkInterval ?? _defaultCheckInterval) >
-                  Duration.zero,
-          'backoffInitialDelay (or checkInterval if implicitly used) must be greater than zero.',
-        ),
-        assert(
-          !useExponentialBackoff ||
-              (backoffInitialDelay ?? checkInterval ?? _defaultCheckInterval) <=
-                  backoffMaxDelay,
-          'backoffInitialDelay (or checkInterval if implicitly used) must be less than or equal to backoffMaxDelay.',
         ) {
+    if (useExponentialBackoff) {
+      if (backoffMultiplier < 1.0) {
+        throw ArgumentError.value(
+          backoffMultiplier,
+          'backoffMultiplier',
+          'Must be >= 1.0 to prevent shrinking intervals.',
+        );
+      }
+      if (backoffMaxDelay <= Duration.zero) {
+        throw ArgumentError.value(
+          backoffMaxDelay,
+          'backoffMaxDelay',
+          'Must be greater than zero.',
+        );
+      }
+      if (_backoffInitialDelay <= Duration.zero) {
+        throw ArgumentError.value(
+          backoffInitialDelay,
+          'backoffInitialDelay',
+          'backoffInitialDelay (or checkInterval if implicitly used) must be greater than zero.',
+        );
+      }
+      if (_backoffInitialDelay > _backoffMaxDelay) {
+        throw ArgumentError(
+          'backoffInitialDelay (or checkInterval if implicitly used) '
+          'must be less than or equal to backoffMaxDelay.',
+        );
+      }
+    }
     _internetCheckOptions = List.unmodifiable([
       if (useDefaultOptions) ..._defaultCheckOptions,
       if (customCheckOptions != null) ...customCheckOptions,

--- a/lib/src/internet_connection.dart
+++ b/lib/src/internet_connection.dart
@@ -208,27 +208,6 @@ class InternetConnection {
   /// The handle for the timer used for periodic status checks.
   Timer? _timerHandle;
 
-  /// Monotonically increasing counter bumped whenever an in-flight
-  /// [_maybeEmitStatusUpdate] must be invalidated: on [setIntervalAndResetTimer]
-  /// and on [_handleStatusChangeCancel].
-  ///
-  /// Each [_maybeEmitStatusUpdate] invocation captures this value on entry.
-  /// Before mutating shared backoff state or scheduling the next timer it
-  /// checks that the value has not changed.  A mismatch means this invocation
-  /// is stale — another caller already rescheduled and owns the next cycle.
-  int _generation = 0;
-
-  /// Monotonically increasing counter bumped only on [_handleStatusChangeCancel].
-  ///
-  /// Captured before the [await internetStatus] gap and compared before
-  /// emitting.  A mismatch means a cancel+resubscribe cycle happened while
-  /// the check was in-flight: the result belongs to the old subscription context
-  /// and must not be emitted to the new subscriber.
-  ///
-  /// Unlike [_generation], this is NOT bumped by [setIntervalAndResetTimer],
-  /// because interval changes do not affect which subscriber owns the result.
-  int _cancelGeneration = 0;
-
   /// Checks if the [Uri] specified in [option] is reachable.
   ///
   /// Returns a [Future] that completes with an [InternetCheckResult] indicating
@@ -265,7 +244,6 @@ class InternetConnection {
       _currentBackoffDelay = backoffOptions!.resolveInitialDelay(duration);
       _backoffNeedsReset = true;
     }
-    _generation++;
     _timerHandle?.cancel();
     _timerHandle = Timer(_checkInterval, _maybeEmitStatusUpdate);
   }
@@ -332,8 +310,6 @@ class InternetConnection {
   /// Updates the status and emits it if there are listeners.
   Future<void> _maybeEmitStatusUpdate() async {
     _timerHandle?.cancel();
-    final generation = _generation;
-    final cancelGeneration = _cancelGeneration;
 
     if (!_statusController.hasListener) return;
 
@@ -343,23 +319,10 @@ class InternetConnection {
 
     final currentStatus = await internetStatus;
 
-    // Only emit if this result still belongs to the current subscription
-    // context.  A cancel+resubscribe while we were awaiting bumps
-    // _cancelGeneration; the new subscriber owns its own fresh check.
-    if (_cancelGeneration == cancelGeneration &&
-        _lastStatus != currentStatus &&
-        _statusController.hasListener) {
+    if (_lastStatus != currentStatus && _statusController.hasListener) {
       _lastStatus = currentStatus;
       _statusController.add(currentStatus);
     }
-
-    if (!_statusController.hasListener) return;
-    // Guard before mutating shared backoff state: a setIntervalAndResetTimer
-    // call that arrived while we were awaiting internetStatus has already
-    // bumped _generation and scheduled its own timer.  Mutating
-    // _currentBackoffDelay / _backoffNeedsReset here would silently overwrite
-    // the reset that setIntervalAndResetTimer applied.
-    if (_generation != generation) return;
 
     Duration nextDelay;
     final options = backoffOptions;
@@ -393,8 +356,6 @@ class InternetConnection {
   Future<void> _handleStatusChangeCancel() async {
     await _triggerSubscription?.cancel();
     _triggerSubscription = null;
-    _cancelGeneration++;
-    _generation++;
     _timerHandle?.cancel();
     _timerHandle = null;
     _lastStatus = null;

--- a/lib/src/internet_connection.dart
+++ b/lib/src/internet_connection.dart
@@ -208,6 +208,18 @@ class InternetConnection {
   /// The handle for the timer used for periodic status checks.
   Timer? _timerHandle;
 
+  /// A counter that goes up by 1 every time something reschedules the
+  /// polling timer directly, i.e. [setIntervalAndResetTimer] or a listener
+  /// cancelling (see [_handleStatusChangeCancel]).
+  ///
+  /// [_maybeEmitStatusUpdate] reads this value before it starts checking the
+  /// connection, then compares it again after the check finishes. If the
+  /// numbers don't match, someone else already changed the backoff state and
+  /// scheduled its own timer while the check was still running, so this (now
+  /// outdated) run must not touch [_currentBackoffDelay]/[_backoffNeedsReset]
+  /// or schedule another timer on top of it.
+  int _timerVersion = 0;
+
   /// Checks if the [Uri] specified in [option] is reachable.
   ///
   /// Returns a [Future] that completes with an [InternetCheckResult] indicating
@@ -244,6 +256,7 @@ class InternetConnection {
       _currentBackoffDelay = backoffOptions!.resolveInitialDelay(duration);
       _backoffNeedsReset = true;
     }
+    _timerVersion++;
     _timerHandle?.cancel();
     _timerHandle = Timer(_checkInterval, _maybeEmitStatusUpdate);
   }
@@ -313,6 +326,8 @@ class InternetConnection {
 
     if (!_statusController.hasListener) return;
 
+    final timerVersion = _timerVersion;
+
     // Snapshot before possible mutation below — needed to detect first-failure
     // vs. ongoing-failure for backoff calculation.
     final previousStatus = _lastStatus;
@@ -323,6 +338,12 @@ class InternetConnection {
       _lastStatus = currentStatus;
       _statusController.add(currentStatus);
     }
+
+    // If setIntervalAndResetTimer ran (or a listener cancelled) while the
+    // check above was running, it already updated the backoff state and
+    // scheduled its own timer. Touching that state or scheduling another
+    // timer here would silently undo what it just set up.
+    if (_timerVersion != timerVersion) return;
 
     Duration nextDelay;
     final options = backoffOptions;
@@ -356,6 +377,7 @@ class InternetConnection {
   Future<void> _handleStatusChangeCancel() async {
     await _triggerSubscription?.cancel();
     _triggerSubscription = null;
+    _timerVersion++;
     _timerHandle?.cancel();
     _timerHandle = null;
     _lastStatus = null;

--- a/lib/src/internet_connection.dart
+++ b/lib/src/internet_connection.dart
@@ -77,7 +77,7 @@ class InternetConnection {
   /// used along with any [customCheckOptions] provided.
   ///
   /// - If [useDefaultOptions] is `false`, you must provide a non-empty
-  /// [customCheckOptions] list.
+  /// [customCheckOptions] list, otherwise an [ArgumentError] is thrown.
   ///
   /// The [customConnectivityCheck] allows you to provide a custom method for
   /// checking endpoint reachability. If provided, it will be used for all
@@ -104,12 +104,13 @@ class InternetConnection {
         _backoffMaxDelay = backoffMaxDelay,
         _backoffMultiplier = backoffMultiplier,
         _currentBackoffDelay =
-            _resolveInitialDelay(backoffInitialDelay, checkInterval),
-        assert(
-          useDefaultOptions || customCheckOptions?.isNotEmpty == true,
-          'You must provide a list of options if you are not using the '
-          'default ones.',
-        ) {
+            _resolveInitialDelay(backoffInitialDelay, checkInterval) {
+    if (!useDefaultOptions && customCheckOptions?.isNotEmpty != true) {
+      throw ArgumentError(
+        'You must provide a list of options if you are not using the '
+        'default ones.',
+      );
+    }
     if (useExponentialBackoff) {
       if (backoffMultiplier < 1.0) {
         throw ArgumentError.value(

--- a/lib/src/internet_connection.dart
+++ b/lib/src/internet_connection.dart
@@ -59,7 +59,7 @@ typedef ConnectivityCheckCallback = Future<InternetCheckResult> Function(
 /// will prevent memory leaks and free up resources.
 ///
 /// ```dart
-/// await listener.cancel();
+/// listener.cancel();
 /// ```
 class InternetConnection {
   /// Returns the singleton instance of [InternetConnection].
@@ -77,33 +77,21 @@ class InternetConnection {
   /// used along with any [customCheckOptions] provided.
   ///
   /// - If [useDefaultOptions] is `false`, you must provide a non-empty
-  /// [customCheckOptions] list, otherwise an [ArgumentError] is thrown.
+  /// [customCheckOptions] list.
   ///
   /// The [customConnectivityCheck] allows you to provide a custom method for
   /// checking endpoint reachability. If provided, it will be used for all
   /// connectivity checks instead of the default HTTP HEAD request
   /// implementation.
   ///
-  /// The [useExponentialBackoff] flag enables exponential backoff for the
-  /// polling interval used by [onStatusChange]. Defaults to `false`, which
-  /// preserves the existing fixed-[checkInterval] polling behaviour exactly.
-  /// When `true`:
-  /// - [backoffInitialDelay] is the delay applied after the first detected
-  ///   failure. If omitted, it defaults to (and tracks) [checkInterval],
-  ///   including through [setIntervalAndResetTimer] calls that don't specify
-  ///   an explicit [backoffInitialDelay].
-  /// - [backoffMaxDelay] caps how large the delay may grow. Defaults to 60
-  ///   seconds.
-  /// - [backoffMultiplier] is the factor applied to the delay on each
-  ///   consecutive failure. Defaults to `2.0`.
-  /// - The delay resets to [checkInterval] as soon as the connection is
-  ///   restored, and resets to [backoffInitialDelay] whenever
-  ///   [setIntervalAndResetTimer] is called or the last listener cancels.
-  ///
-  /// An [ArgumentError] is thrown if [useExponentialBackoff] is `true` and
-  /// [backoffMultiplier] is not a finite number `>= 1.0`, or if
-  /// [backoffMaxDelay] or the effective [backoffInitialDelay] is not a
-  /// positive [Duration] no greater than [backoffMaxDelay].
+  /// The [backoffOptions] enables exponential backoff for the polling
+  /// interval used by [onStatusChange]. Defaults to `null`, which preserves
+  /// the existing fixed-[checkInterval] polling behaviour exactly. When
+  /// provided, the delay grows on consecutive failures (as configured by
+  /// [ExponentialBackoffOptions]), resets to [checkInterval] as soon as the
+  /// connection is restored, and resets to the configured initial delay
+  /// whenever [setIntervalAndResetTimer] is called or the last listener
+  /// cancels.
   ///
   /// Make sure to call [dispose] when this instance is no longer needed to free
   /// up resources.
@@ -114,54 +102,17 @@ class InternetConnection {
     this.enableStrictCheck = false,
     this.customConnectivityCheck,
     this.triggerStream,
-    this.useExponentialBackoff = false,
-    Duration? backoffInitialDelay,
-    Duration backoffMaxDelay = const Duration(seconds: 60),
-    double backoffMultiplier = 2.0,
+    this.backoffOptions,
   })  : _checkInterval = checkInterval ?? _defaultCheckInterval,
-        _backoffInitialDelayExplicit = backoffInitialDelay != null,
-        _backoffInitialDelay =
-            _resolveInitialDelay(backoffInitialDelay, checkInterval),
-        _backoffMaxDelay = backoffMaxDelay,
-        _backoffMultiplier = backoffMultiplier,
-        _currentBackoffDelay =
-            _resolveInitialDelay(backoffInitialDelay, checkInterval) {
-    if (!useDefaultOptions && customCheckOptions?.isNotEmpty != true) {
-      throw ArgumentError(
-        'You must provide a list of options if you are not using the '
-        'default ones.',
-      );
-    }
-    if (useExponentialBackoff) {
-      if (!backoffMultiplier.isFinite || backoffMultiplier < 1.0) {
-        throw ArgumentError.value(
-          backoffMultiplier,
-          'backoffMultiplier',
-          'Must be a finite number >= 1.0 to prevent shrinking or invalid '
-              'intervals.',
-        );
-      }
-      if (backoffMaxDelay <= Duration.zero) {
-        throw ArgumentError.value(
-          backoffMaxDelay,
-          'backoffMaxDelay',
-          'Must be greater than zero.',
-        );
-      }
-      if (_backoffInitialDelay <= Duration.zero) {
-        throw ArgumentError.value(
-          _backoffInitialDelay,
-          'backoffInitialDelay',
-          'backoffInitialDelay (or checkInterval if implicitly used) must be greater than zero.',
-        );
-      }
-      if (_backoffInitialDelay > _backoffMaxDelay) {
-        throw ArgumentError(
-          'backoffInitialDelay (or checkInterval if implicitly used) '
-          'must be less than or equal to backoffMaxDelay.',
-        );
-      }
-    }
+        _currentBackoffDelay = backoffOptions?.resolveInitialDelay(
+              checkInterval ?? _defaultCheckInterval,
+            ) ??
+            Duration.zero,
+        assert(
+          useDefaultOptions || customCheckOptions?.isNotEmpty == true,
+          'You must provide a list of options if you are not using the '
+          'default ones.',
+        ) {
     _internetCheckOptions = List.unmodifiable([
       if (useDefaultOptions) ..._defaultCheckOptions,
       if (customCheckOptions != null) ...customCheckOptions,
@@ -176,12 +127,6 @@ class InternetConnection {
 
   /// The default check interval duration.
   static const _defaultCheckInterval = Duration(seconds: 10);
-
-  static Duration _resolveInitialDelay(
-    Duration? backoffInitialDelay,
-    Duration? checkInterval,
-  ) =>
-      backoffInitialDelay ?? checkInterval ?? _defaultCheckInterval;
 
   /// The default list of [Uri]s used for checking internet reachability.
   static final _defaultCheckOptions = List<InternetCheckOption>.unmodifiable([
@@ -239,42 +184,22 @@ class InternetConnection {
   /// whenever it emits an event.
   final Stream? triggerStream;
 
-  /// Whether exponential backoff is enabled for the polling interval.
+  /// The exponential backoff configuration for the polling interval used by
+  /// [onStatusChange].
   ///
-  /// When `true`, the polling interval grows on consecutive failures and resets
-  /// to [checkInterval] when the connection is restored.
-  ///
-  /// Defaults to `false`.
-  final bool useExponentialBackoff;
-
-  /// Whether [_backoffInitialDelay] was explicitly provided by the caller.
-  ///
-  /// When `false`, [_backoffInitialDelay] tracks [_checkInterval] so that
-  /// a [setIntervalAndResetTimer] call keeps both values in sync.
-  final bool _backoffInitialDelayExplicit;
-
-  /// The initial delay used on the first failure when backoff is enabled.
-  ///
-  /// Defaults to [checkInterval]. Updated by [setIntervalAndResetTimer] when
-  /// no explicit value was provided at construction time.
-  Duration _backoffInitialDelay;
-
-  /// The upper bound on the backoff delay.
-  ///
-  /// Defaults to 60 seconds.
-  final Duration _backoffMaxDelay;
-
-  /// The multiplicative factor applied to the delay on each consecutive failure.
-  ///
-  /// Defaults to 2.0.
-  final double _backoffMultiplier;
+  /// When `null` (the default), the polling interval stays fixed at
+  /// [checkInterval]. When provided, the delay grows on consecutive failures
+  /// and resets to [checkInterval] when the connection is restored.
+  final ExponentialBackoffOptions? backoffOptions;
 
   /// Whether the backoff state was forcefully reset by an interval change.
   bool _backoffNeedsReset = false;
 
-  /// The live backoff delay, updated each polling cycle when backoff is enabled.
+  /// The live backoff delay, updated each polling cycle when [backoffOptions]
+  /// is set.
   ///
-  /// Resets to [_backoffInitialDelay] on reconnect or subscription cancel.
+  /// Resets to the configured initial delay on reconnect or subscription
+  /// cancel.
   Duration _currentBackoffDelay;
 
   /// The last known internet connection status result.
@@ -336,11 +261,8 @@ class InternetConnection {
   /// resets the connection checking timer.
   void setIntervalAndResetTimer(Duration duration) {
     _checkInterval = duration;
-    if (useExponentialBackoff) {
-      // Keep _backoffInitialDelay in sync with the new checkInterval when the
-      // caller never provided an explicit backoffInitialDelay.
-      if (!_backoffInitialDelayExplicit) _backoffInitialDelay = duration;
-      _currentBackoffDelay = _backoffInitialDelay;
+    if (backoffOptions != null) {
+      _currentBackoffDelay = backoffOptions!.resolveInitialDelay(duration);
       _backoffNeedsReset = true;
     }
     _generation++;
@@ -351,27 +273,12 @@ class InternetConnection {
   /// Returns the current duration between connection checks.
   Duration get checkInterval => _checkInterval;
 
-  /// Returns the delay applied after the first detected failure when
-  /// [useExponentialBackoff] is enabled.
-  ///
-  /// If no explicit value was provided at construction time, this tracks
-  /// [checkInterval], including through [setIntervalAndResetTimer] calls.
-  Duration get backoffInitialDelay => _backoffInitialDelay;
-
-  /// Returns the configured upper bound on the backoff delay when
-  /// [useExponentialBackoff] is enabled.
-  Duration get backoffMaxDelay => _backoffMaxDelay;
-
-  /// Returns the configured multiplicative factor applied to the delay on
-  /// each consecutive failure when [useExponentialBackoff] is enabled.
-  double get backoffMultiplier => _backoffMultiplier;
-
   /// Returns the delay that will be used before the next poll when
-  /// [useExponentialBackoff] is enabled.
+  /// [backoffOptions] is set.
   ///
-  /// Useful for surfacing "retrying in Xs" style UI. Resets to
-  /// [backoffInitialDelay] on reconnect, on [setIntervalAndResetTimer], and
-  /// when the last listener cancels.
+  /// Exposed so apps can surface "retrying in Xs" style UI. Resets to the
+  /// configured initial delay on reconnect, on [setIntervalAndResetTimer],
+  /// and when the last listener cancels.
   Duration get currentBackoffDelay => _currentBackoffDelay;
 
   /// Checks if there is internet access by verifying connectivity to the
@@ -455,32 +362,26 @@ class InternetConnection {
     if (_generation != generation) return;
 
     Duration nextDelay;
-    if (useExponentialBackoff) {
-      if (currentStatus == InternetStatus.connected) {
-        _currentBackoffDelay = _backoffInitialDelay;
-        nextDelay = _checkInterval;
-      } else if (previousStatus != InternetStatus.disconnected ||
-          _backoffNeedsReset) {
-        // First failure: previousStatus is either null (first ever poll) or
-        // connected — both mean we have not yet been in a backoff streak.
-        // Also, if _backoffNeedsReset is true, we treat this as a first failure to
-        // reset the backoff delay, even if the previous status was already disconnected.
-        _backoffNeedsReset = false;
-        _currentBackoffDelay = _backoffInitialDelay > _backoffMaxDelay
-            ? _backoffMaxDelay
-            : _backoffInitialDelay;
-        nextDelay = _currentBackoffDelay;
-      } else {
-        // Ongoing failure: grow the delay.
-        final ms =
-            (_currentBackoffDelay.inMilliseconds * _backoffMultiplier).round();
-        _currentBackoffDelay = Duration(
-          milliseconds: ms.clamp(0, _backoffMaxDelay.inMilliseconds).toInt(),
-        );
-        nextDelay = _currentBackoffDelay;
-      }
-    } else {
+    final options = backoffOptions;
+    if (options == null) {
       nextDelay = _checkInterval;
+    } else if (currentStatus == InternetStatus.connected) {
+      _currentBackoffDelay = options.resolveInitialDelay(_checkInterval);
+      nextDelay = _checkInterval;
+    } else {
+      // A failure is either the first in a new streak — previousStatus is
+      // null (first ever poll) or connected, or _backoffNeedsReset was set
+      // by setIntervalAndResetTimer/a new subscription — or an ongoing
+      // streak, in which case the delay keeps growing.
+      final isFirstFailure =
+          previousStatus != InternetStatus.disconnected || _backoffNeedsReset;
+      _backoffNeedsReset = false;
+      _currentBackoffDelay = options.nextDelay(
+        current: _currentBackoffDelay,
+        isFirstFailure: isFirstFailure,
+        checkInterval: _checkInterval,
+      );
+      nextDelay = _currentBackoffDelay;
     }
 
     _timerHandle = Timer(nextDelay, _maybeEmitStatusUpdate);
@@ -498,7 +399,10 @@ class InternetConnection {
     _timerHandle = null;
     _lastStatus = null;
     _backoffNeedsReset = false;
-    if (useExponentialBackoff) _currentBackoffDelay = _backoffInitialDelay;
+    if (backoffOptions != null) {
+      _currentBackoffDelay =
+          backoffOptions!.resolveInitialDelay(_checkInterval);
+    }
   }
 
   /// The result of the last attempt to check the internet status.

--- a/lib/src/internet_connection.dart
+++ b/lib/src/internet_connection.dart
@@ -84,6 +84,27 @@ class InternetConnection {
   /// connectivity checks instead of the default HTTP HEAD request
   /// implementation.
   ///
+  /// The [useExponentialBackoff] flag enables exponential backoff for the
+  /// polling interval used by [onStatusChange]. Defaults to `false`, which
+  /// preserves the existing fixed-[checkInterval] polling behaviour exactly.
+  /// When `true`:
+  /// - [backoffInitialDelay] is the delay applied after the first detected
+  ///   failure. If omitted, it defaults to (and tracks) [checkInterval],
+  ///   including through [setIntervalAndResetTimer] calls that don't specify
+  ///   an explicit [backoffInitialDelay].
+  /// - [backoffMaxDelay] caps how large the delay may grow. Defaults to 60
+  ///   seconds.
+  /// - [backoffMultiplier] is the factor applied to the delay on each
+  ///   consecutive failure. Defaults to `2.0`.
+  /// - The delay resets to [checkInterval] as soon as the connection is
+  ///   restored, and resets to [backoffInitialDelay] whenever
+  ///   [setIntervalAndResetTimer] is called or the last listener cancels.
+  ///
+  /// An [ArgumentError] is thrown if [useExponentialBackoff] is `true` and
+  /// [backoffMultiplier] is not a finite number `>= 1.0`, or if
+  /// [backoffMaxDelay] or the effective [backoffInitialDelay] is not a
+  /// positive [Duration] no greater than [backoffMaxDelay].
+  ///
   /// Make sure to call [dispose] when this instance is no longer needed to free
   /// up resources.
   InternetConnection.createInstance({
@@ -112,11 +133,12 @@ class InternetConnection {
       );
     }
     if (useExponentialBackoff) {
-      if (backoffMultiplier < 1.0) {
+      if (!backoffMultiplier.isFinite || backoffMultiplier < 1.0) {
         throw ArgumentError.value(
           backoffMultiplier,
           'backoffMultiplier',
-          'Must be >= 1.0 to prevent shrinking intervals.',
+          'Must be a finite number >= 1.0 to prevent shrinking or invalid '
+              'intervals.',
         );
       }
       if (backoffMaxDelay <= Duration.zero) {
@@ -328,6 +350,29 @@ class InternetConnection {
 
   /// Returns the current duration between connection checks.
   Duration get checkInterval => _checkInterval;
+
+  /// Returns the delay applied after the first detected failure when
+  /// [useExponentialBackoff] is enabled.
+  ///
+  /// If no explicit value was provided at construction time, this tracks
+  /// [checkInterval], including through [setIntervalAndResetTimer] calls.
+  Duration get backoffInitialDelay => _backoffInitialDelay;
+
+  /// Returns the configured upper bound on the backoff delay when
+  /// [useExponentialBackoff] is enabled.
+  Duration get backoffMaxDelay => _backoffMaxDelay;
+
+  /// Returns the configured multiplicative factor applied to the delay on
+  /// each consecutive failure when [useExponentialBackoff] is enabled.
+  double get backoffMultiplier => _backoffMultiplier;
+
+  /// Returns the delay that will be used before the next poll when
+  /// [useExponentialBackoff] is enabled.
+  ///
+  /// Useful for surfacing "retrying in Xs" style UI. Resets to
+  /// [backoffInitialDelay] on reconnect, on [setIntervalAndResetTimer], and
+  /// when the last listener cancels.
+  Duration get currentBackoffDelay => _currentBackoffDelay;
 
   /// Checks if there is internet access by verifying connectivity to the
   /// specified [Uri]s.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ environment:
 
 dependencies:
   http: ^1.0.0
+  meta: ^1.9.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/test/exponential_backoff_options_test.dart
+++ b/test/exponential_backoff_options_test.dart
@@ -1,0 +1,183 @@
+import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ExponentialBackoffOptions', () {
+    test('toString() returns correct string representation', () {
+      final options = ExponentialBackoffOptions(
+        initialDelay: const Duration(milliseconds: 500),
+        maxDelay: const Duration(seconds: 30),
+        multiplier: 3.0,
+      );
+
+      const expectedString = 'ExponentialBackoffOptions(\n'
+          '  initialDelay: 0:00:00.500000,\n'
+          '  maxDelay: 0:00:30.000000,\n'
+          '  multiplier: 3.0\n'
+          ')';
+
+      expect(options.toString(), expectedString);
+    });
+
+    test('two instances with the same values are equal', () {
+      final a = ExponentialBackoffOptions(
+        initialDelay: const Duration(milliseconds: 500),
+        maxDelay: const Duration(seconds: 30),
+        multiplier: 3.0,
+      );
+      final b = ExponentialBackoffOptions(
+        initialDelay: const Duration(milliseconds: 500),
+        maxDelay: const Duration(seconds: 30),
+        multiplier: 3.0,
+      );
+
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+    });
+
+    group('constructor validation', () {
+      // multiplier < 1.0 would cause the delay to shrink on each failure,
+      // eventually collapsing to 0 and creating a busy-poll loop.
+      test('throws when multiplier is less than 1.0', () {
+        expect(
+          () => ExponentialBackoffOptions(multiplier: 0.5),
+          throwsA(isA<AssertionError>()),
+        );
+      });
+
+      // 1.0 is the boundary: flat-rate backoff (delay never grows) is valid,
+      // since the interval still resets on reconnect as documented.
+      test('allows multiplier equal to 1.0', () {
+        expect(
+          () => ExponentialBackoffOptions(multiplier: 1.0),
+          returnsNormally,
+        );
+      });
+
+      // Duration.zero initial delay fires the next timer immediately on the
+      // first failure, indistinguishable from having no backoff at all.
+      test('throws when initialDelay is zero', () {
+        expect(
+          () => ExponentialBackoffOptions(initialDelay: Duration.zero),
+          throwsA(isA<AssertionError>()),
+        );
+      });
+
+      // initialDelay > maxDelay means the very first backed-off poll already
+      // exceeds the configured ceiling — the ceiling becomes meaningless.
+      test('throws when initialDelay exceeds maxDelay', () {
+        expect(
+          () => ExponentialBackoffOptions(
+            initialDelay: const Duration(seconds: 10),
+            maxDelay: const Duration(seconds: 5),
+          ),
+          throwsA(isA<AssertionError>()),
+        );
+      });
+
+      test('throws when maxDelay is zero', () {
+        expect(
+          () => ExponentialBackoffOptions(maxDelay: Duration.zero),
+          throwsA(isA<AssertionError>()),
+        );
+      });
+
+      // NaN and Infinity both fail `< 1.0` (IEEE-754 comparisons involving
+      // NaN are always false), so a naive lower-bound check alone would let
+      // them through only to crash later when `.round()` is called on the
+      // grown delay during an ongoing failure.
+      test('throws when multiplier is NaN', () {
+        expect(
+          () => ExponentialBackoffOptions(multiplier: double.nan),
+          throwsA(isA<AssertionError>()),
+        );
+      });
+
+      test('throws when multiplier is Infinity', () {
+        expect(
+          () => ExponentialBackoffOptions(multiplier: double.infinity),
+          throwsA(isA<AssertionError>()),
+        );
+      });
+    });
+
+    group('resolveInitialDelay', () {
+      test('falls back to checkInterval when initialDelay is omitted', () {
+        final options = ExponentialBackoffOptions();
+
+        expect(
+          options.resolveInitialDelay(const Duration(seconds: 10)),
+          const Duration(seconds: 10),
+        );
+      });
+
+      test('uses the explicit initialDelay when provided', () {
+        final options = ExponentialBackoffOptions(
+          initialDelay: const Duration(milliseconds: 200),
+        );
+
+        expect(
+          options.resolveInitialDelay(const Duration(seconds: 10)),
+          const Duration(milliseconds: 200),
+        );
+      });
+
+      test('caps the resolved delay at maxDelay', () {
+        final options = ExponentialBackoffOptions(
+          maxDelay: const Duration(milliseconds: 100),
+        );
+
+        expect(
+          options.resolveInitialDelay(const Duration(seconds: 10)),
+          const Duration(milliseconds: 100),
+        );
+      });
+    });
+
+    group('nextDelay', () {
+      test('returns the resolved initial delay on first failure', () {
+        final options = ExponentialBackoffOptions(
+          initialDelay: const Duration(milliseconds: 100),
+        );
+
+        expect(
+          options.nextDelay(
+            current: const Duration(milliseconds: 400),
+            isFirstFailure: true,
+            checkInterval: const Duration(seconds: 10),
+          ),
+          const Duration(milliseconds: 100),
+        );
+      });
+
+      test('grows the current delay by multiplier on an ongoing failure', () {
+        final options = ExponentialBackoffOptions(multiplier: 2.0);
+
+        expect(
+          options.nextDelay(
+            current: const Duration(milliseconds: 100),
+            isFirstFailure: false,
+            checkInterval: const Duration(seconds: 10),
+          ),
+          const Duration(milliseconds: 200),
+        );
+      });
+
+      test('caps the grown delay at maxDelay', () {
+        final options = ExponentialBackoffOptions(
+          maxDelay: const Duration(milliseconds: 150),
+          multiplier: 2.0,
+        );
+
+        expect(
+          options.nextDelay(
+            current: const Duration(milliseconds: 100),
+            isFirstFailure: false,
+            checkInterval: const Duration(seconds: 10),
+          ),
+          const Duration(milliseconds: 150),
+        );
+      });
+    });
+  });
+}

--- a/test/internet_connection_test.dart
+++ b/test/internet_connection_test.dart
@@ -264,7 +264,8 @@ void main() {
         Duration backoffMaxDelay = const Duration(milliseconds: 800),
         double backoffMultiplier = 2.0,
       }) {
-        final option = InternetCheckOption(uri: Uri.parse('https://example.com'));
+        final option =
+            InternetCheckOption(uri: Uri.parse('https://example.com'));
         return InternetConnection.createInstance(
           checkInterval: checkInterval,
           useDefaultOptions: false,
@@ -411,10 +412,7 @@ void main() {
         // The gap between the disconnect-detecting call and the next call
         // should be around initialDelay (200ms), not checkInterval (100ms).
         if (callLog.length >= 2) {
-          final gap = callLog[1]
-              .difference(callLog[0])
-              .inMilliseconds
-              .abs();
+          final gap = callLog[1].difference(callLog[0]).inMilliseconds.abs();
           expect(gap, greaterThan(150));
         }
       });
@@ -442,8 +440,7 @@ void main() {
         // Verify that gaps between consecutive calls are non-decreasing.
         final gaps = <int>[];
         for (int i = 1; i < callLog.length; i++) {
-          gaps.add(
-              callLog[i].difference(callLog[i - 1]).inMilliseconds.abs());
+          gaps.add(callLog[i].difference(callLog[i - 1]).inMilliseconds.abs());
         }
         for (int i = 1; i < gaps.length; i++) {
           // Each gap should be >= the previous one (allowing 20ms tolerance).
@@ -546,15 +543,14 @@ void main() {
         // (restarted backoff sequence: 50, 100, 200ms…).
         expect(callLog.length, greaterThanOrEqualTo(2));
         if (callLog.length >= 3) {
-          final gap1 =
-              callLog[1].difference(callLog[0]).inMilliseconds.abs();
-          final gap2 =
-              callLog[2].difference(callLog[1]).inMilliseconds.abs();
+          final gap1 = callLog[1].difference(callLog[0]).inMilliseconds.abs();
+          final gap2 = callLog[2].difference(callLog[1]).inMilliseconds.abs();
           expect(gap2 + 20, greaterThanOrEqualTo(gap1));
         }
       });
 
-      test('setIntervalAndResetTimer syncs implicit backoffInitialDelay', () async {
+      test('setIntervalAndResetTimer syncs implicit backoffInitialDelay',
+          () async {
         final callLog = <DateTime>[];
 
         // Intentionally omit `backoffInitialDelay` and rely on `checkInterval` (50ms)
@@ -587,10 +583,11 @@ void main() {
         sub.cancel();
 
         expect(callLog.length, greaterThanOrEqualTo(2));
-        
+
         if (callLog.length >= 2) {
-          final firstGap = callLog[1].difference(callLog[0]).inMilliseconds.abs();
-          
+          final firstGap =
+              callLog[1].difference(callLog[0]).inMilliseconds.abs();
+
           // If it follows, it should be around 100ms; if not, it would be around 50ms
           // Verify that it is greater than 80ms to ensure it followed 100ms
           expect(firstGap, greaterThan(80));
@@ -660,10 +657,7 @@ void main() {
         expect(callLog.length, greaterThanOrEqualTo(2));
 
         if (callLog.length >= 2) {
-          final gap = callLog[1]
-              .difference(callLog[0])
-              .inMilliseconds
-              .abs();
+          final gap = callLog[1].difference(callLog[0]).inMilliseconds.abs();
           // initialDelay is 100ms; ongoing backoff of 100ms would also be 100ms
           // on first step, but 200ms on second. We verify the first gap is ~100ms.
           expect(gap, greaterThan(60));

--- a/test/internet_connection_test.dart
+++ b/test/internet_connection_test.dart
@@ -346,26 +346,35 @@ void main() {
 
       test('disabled by default: interval stays constant under failures',
           () async {
-        await TestHttpClient.run((client) async {
-          client.responseBuilder = (_) =>
-              TestHttpClient.createResponse(statusCode: 500);
+        final callLog = <DateTime>[];
 
-          final sub = InternetConnection.createInstance(
-            checkInterval: const Duration(milliseconds: 100),
-            useDefaultOptions: false,
-            customCheckOptions: [
-              InternetCheckOption(uri: Uri.parse('https://www.example.com')),
-            ],
-          ).onStatusChange.listen((_) {});
+        final checker = InternetConnection.createInstance(
+          checkInterval: const Duration(milliseconds: 100),
+          useDefaultOptions: false,
+          customCheckOptions: [
+            InternetCheckOption(uri: Uri.parse('https://www.example.com')),
+          ],
+          customConnectivityCheck: (opt) async {
+            callLog.add(DateTime.now());
+            return InternetCheckResult(option: opt, isSuccess: false);
+          },
+        );
 
-          await Future.delayed(const Duration(milliseconds: 500));
+        final sub = checker.onStatusChange.listen((_) {});
+        await Future.delayed(const Duration(milliseconds: 550));
+        sub.cancel();
 
-          // Count calls by measuring the subscription timer indirectly:
-          // with a 100ms interval over 500ms we expect ~4-6 checks total.
-          // We only verify the subscription fires at least once (disconnected).
-          expect(sub, isNotNull);
-          sub.cancel();
-        });
+        // With a 100ms interval over 550ms we expect ~4-5 checks.
+        expect(callLog.length, greaterThanOrEqualTo(4));
+
+        // All gaps should stay near 100ms — no backoff growth.
+        for (int i = 1; i < callLog.length; i++) {
+          final gap =
+              callLog[i].difference(callLog[i - 1]).inMilliseconds.abs();
+          expect(gap, lessThan(200),
+              reason: 'gap between check $i and ${i - 1} was ${gap}ms '
+                  '— expected ~100ms (constant interval, no backoff)');
+        }
       });
 
       test('first failure sets initialDelay', () async {

--- a/test/internet_connection_test.dart
+++ b/test/internet_connection_test.dart
@@ -280,6 +280,70 @@ void main() {
         );
       }
 
+      group('constructor validation', () {
+        // One custom option is enough to satisfy the non-default-options assert.
+        final singleOption = [
+          InternetCheckOption(uri: Uri.parse('https://example.com')),
+        ];
+
+        // backoffMultiplier < 1.0 would cause the delay to shrink on each
+        // failure, eventually collapsing to 0 and creating a busy-poll loop.
+        test('throws when backoffMultiplier is less than 1.0', () {
+          expect(
+            () => InternetConnection.createInstance(
+              useExponentialBackoff: true,
+              useDefaultOptions: false,
+              customCheckOptions: singleOption,
+              backoffMultiplier: 0.5,
+            ),
+            throwsA(isA<AssertionError>()),
+          );
+        });
+
+        // 1.0 is the boundary: flat-rate backoff (delay never grows) is valid,
+        // since the interval still resets on reconnect as documented.
+        test('allows backoffMultiplier equal to 1.0', () {
+          expect(
+            () => InternetConnection.createInstance(
+              useExponentialBackoff: true,
+              useDefaultOptions: false,
+              customCheckOptions: singleOption,
+              backoffMultiplier: 1.0,
+            ),
+            returnsNormally,
+          );
+        });
+
+        // Duration.zero initial delay fires the next timer immediately on the
+        // first failure, indistinguishable from having no backoff at all.
+        test('throws when backoffInitialDelay is zero', () {
+          expect(
+            () => InternetConnection.createInstance(
+              useExponentialBackoff: true,
+              useDefaultOptions: false,
+              customCheckOptions: singleOption,
+              backoffInitialDelay: Duration.zero,
+            ),
+            throwsA(isA<AssertionError>()),
+          );
+        });
+
+        // initialDelay > maxDelay means the very first backed-off poll already
+        // exceeds the configured ceiling — the ceiling becomes meaningless.
+        test('throws when backoffInitialDelay exceeds backoffMaxDelay', () {
+          expect(
+            () => InternetConnection.createInstance(
+              useExponentialBackoff: true,
+              useDefaultOptions: false,
+              customCheckOptions: singleOption,
+              backoffInitialDelay: const Duration(seconds: 10),
+              backoffMaxDelay: const Duration(seconds: 5),
+            ),
+            throwsA(isA<AssertionError>()),
+          );
+        });
+      });
+
       test('disabled by default: interval stays constant under failures',
           () async {
         await TestHttpClient.run((client) async {

--- a/test/internet_connection_test.dart
+++ b/test/internet_connection_test.dart
@@ -252,5 +252,308 @@ void main() {
       final checker = InternetConnection.createInstance();
       expect(checker, isNot(InternetConnection.createInstance()));
     });
+
+    group('exponentialBackoff', () {
+      // Helper: build a checker that uses customConnectivityCheck so we
+      // avoid real network calls and record each invocation timestamp.
+      InternetConnection makeChecker({
+        required bool Function() shouldSucceed,
+        required List<DateTime> callLog,
+        Duration checkInterval = const Duration(milliseconds: 100),
+        Duration? backoffInitialDelay,
+        Duration backoffMaxDelay = const Duration(milliseconds: 800),
+        double backoffMultiplier = 2.0,
+      }) {
+        final option = InternetCheckOption(uri: Uri.parse('https://example.com'));
+        return InternetConnection.createInstance(
+          checkInterval: checkInterval,
+          useDefaultOptions: false,
+          customCheckOptions: [option],
+          useExponentialBackoff: true,
+          backoffInitialDelay: backoffInitialDelay,
+          backoffMaxDelay: backoffMaxDelay,
+          backoffMultiplier: backoffMultiplier,
+          customConnectivityCheck: (opt) async {
+            callLog.add(DateTime.now());
+            return InternetCheckResult(option: opt, isSuccess: shouldSucceed());
+          },
+        );
+      }
+
+      test('disabled by default: interval stays constant under failures',
+          () async {
+        await TestHttpClient.run((client) async {
+          client.responseBuilder = (_) =>
+              TestHttpClient.createResponse(statusCode: 500);
+
+          final sub = InternetConnection.createInstance(
+            checkInterval: const Duration(milliseconds: 100),
+            useDefaultOptions: false,
+            customCheckOptions: [
+              InternetCheckOption(uri: Uri.parse('https://www.example.com')),
+            ],
+          ).onStatusChange.listen((_) {});
+
+          await Future.delayed(const Duration(milliseconds: 500));
+
+          // Count calls by measuring the subscription timer indirectly:
+          // with a 100ms interval over 500ms we expect ~4-6 checks total.
+          // We only verify the subscription fires at least once (disconnected).
+          expect(sub, isNotNull);
+          sub.cancel();
+        });
+      });
+
+      test('first failure sets initialDelay', () async {
+        bool connected = true;
+        final callLog = <DateTime>[];
+
+        final checker = makeChecker(
+          shouldSucceed: () => connected,
+          callLog: callLog,
+          checkInterval: const Duration(milliseconds: 100),
+          backoffInitialDelay: const Duration(milliseconds: 200),
+        );
+
+        final sub = checker.onStatusChange.listen((_) {});
+
+        // Wait for at least one connected check.
+        await Future.delayed(const Duration(milliseconds: 150));
+        callLog.clear();
+
+        // Trigger a disconnect.
+        connected = false;
+
+        // Wait long enough for the disconnect to be detected and one backoff
+        // cycle to elapse (~100ms for detect + ~200ms for the backoff timer).
+        await Future.delayed(const Duration(milliseconds: 450));
+
+        sub.cancel();
+
+        // We should have at most 2 calls in this window:
+        // one that detected the disconnect, and at most one more after
+        // the 200ms initialDelay fires.
+        expect(callLog.length, lessThanOrEqualTo(3));
+
+        // The gap between the disconnect-detecting call and the next call
+        // should be around initialDelay (200ms), not checkInterval (100ms).
+        if (callLog.length >= 2) {
+          final gap = callLog[1]
+              .difference(callLog[0])
+              .inMilliseconds
+              .abs();
+          expect(gap, greaterThan(150));
+        }
+      });
+
+      test('delay grows on consecutive failures', () async {
+        final callLog = <DateTime>[];
+
+        final checker = makeChecker(
+          shouldSucceed: () => false,
+          callLog: callLog,
+          checkInterval: const Duration(milliseconds: 50),
+          backoffInitialDelay: const Duration(milliseconds: 50),
+          backoffMaxDelay: const Duration(milliseconds: 800),
+          backoffMultiplier: 2.0,
+        );
+
+        final sub = checker.onStatusChange.listen((_) {});
+
+        // Total expected time for ~4 checks: 50 + 50 + 100 + 200 = 400ms
+        await Future.delayed(const Duration(milliseconds: 550));
+        sub.cancel();
+
+        expect(callLog.length, greaterThanOrEqualTo(4));
+
+        // Verify that gaps between consecutive calls are non-decreasing.
+        final gaps = <int>[];
+        for (int i = 1; i < callLog.length; i++) {
+          gaps.add(
+              callLog[i].difference(callLog[i - 1]).inMilliseconds.abs());
+        }
+        for (int i = 1; i < gaps.length; i++) {
+          // Each gap should be >= the previous one (allowing 20ms tolerance).
+          expect(gaps[i] + 20, greaterThanOrEqualTo(gaps[i - 1]));
+        }
+      });
+
+      test('delay is capped at maxDelay', () async {
+        final callLog = <DateTime>[];
+
+        final checker = makeChecker(
+          shouldSucceed: () => false,
+          callLog: callLog,
+          checkInterval: const Duration(milliseconds: 50),
+          backoffInitialDelay: const Duration(milliseconds: 50),
+          backoffMaxDelay: const Duration(milliseconds: 200),
+          backoffMultiplier: 2.0,
+        );
+
+        final sub = checker.onStatusChange.listen((_) {});
+
+        // Run long enough for the delay to have hit the cap and stayed there.
+        // 50 + 50 + 100 + 200 + 200 = 600ms total for 5 calls.
+        await Future.delayed(const Duration(milliseconds: 900));
+        sub.cancel();
+
+        expect(callLog.length, greaterThanOrEqualTo(4));
+
+        // After the cap is reached, no gap should exceed maxDelay by much.
+        for (int i = 3; i < callLog.length; i++) {
+          final gap =
+              callLog[i].difference(callLog[i - 1]).inMilliseconds.abs();
+          expect(gap, lessThan(350)); // maxDelay 200ms + generous tolerance
+        }
+      });
+
+      test('delay resets to checkInterval on reconnect', () async {
+        bool connected = false;
+        final callLog = <DateTime>[];
+
+        final checker = makeChecker(
+          shouldSucceed: () => connected,
+          callLog: callLog,
+          checkInterval: const Duration(milliseconds: 50),
+          backoffInitialDelay: const Duration(milliseconds: 50),
+          backoffMaxDelay: const Duration(milliseconds: 200),
+          backoffMultiplier: 2.0,
+        );
+
+        final sub = checker.onStatusChange.listen((_) {});
+
+        // Let backoff grow toward maxDelay.
+        await Future.delayed(const Duration(milliseconds: 500));
+
+        // Reconnect and flush the log.
+        connected = true;
+        callLog.clear();
+
+        // After reconnect, polling should revert to checkInterval (50ms).
+        await Future.delayed(const Duration(milliseconds: 300));
+        sub.cancel();
+
+        // With 50ms interval over 300ms we expect ~5 calls.
+        expect(callLog.length, greaterThanOrEqualTo(3));
+
+        // All gaps should be close to checkInterval (50ms), not maxDelay.
+        for (int i = 1; i < callLog.length; i++) {
+          final gap =
+              callLog[i].difference(callLog[i - 1]).inMilliseconds.abs();
+          expect(gap, lessThan(200));
+        }
+      });
+
+      test('setIntervalAndResetTimer resets backoff state', () async {
+        bool connected = false;
+        final callLog = <DateTime>[];
+
+        final checker = makeChecker(
+          shouldSucceed: () => connected,
+          callLog: callLog,
+          checkInterval: const Duration(milliseconds: 50),
+          backoffInitialDelay: const Duration(milliseconds: 50),
+          backoffMaxDelay: const Duration(milliseconds: 200),
+          backoffMultiplier: 2.0,
+        );
+
+        final sub = checker.onStatusChange.listen((_) {});
+
+        // Let backoff reach maxDelay.
+        await Future.delayed(const Duration(milliseconds: 600));
+        callLog.clear();
+
+        // Resetting the interval should restart backoff from initialDelay.
+        checker.setIntervalAndResetTimer(const Duration(milliseconds: 50));
+
+        await Future.delayed(const Duration(milliseconds: 400));
+        sub.cancel();
+
+        // Should have ~3-5 calls; the gaps should be non-decreasing again
+        // (restarted backoff sequence: 50, 100, 200ms…).
+        expect(callLog.length, greaterThanOrEqualTo(2));
+        if (callLog.length >= 3) {
+          final gap1 =
+              callLog[1].difference(callLog[0]).inMilliseconds.abs();
+          final gap2 =
+              callLog[2].difference(callLog[1]).inMilliseconds.abs();
+          expect(gap2 + 20, greaterThanOrEqualTo(gap1));
+        }
+      });
+
+      test('re-subscription resets backoff state', () async {
+        bool connected = false;
+        final callLog = <DateTime>[];
+
+        final checker = makeChecker(
+          shouldSucceed: () => connected,
+          callLog: callLog,
+          checkInterval: const Duration(milliseconds: 50),
+          backoffInitialDelay: const Duration(milliseconds: 50),
+          backoffMaxDelay: const Duration(milliseconds: 200),
+          backoffMultiplier: 2.0,
+        );
+
+        // First subscription — let backoff grow.
+        final sub1 = checker.onStatusChange.listen((_) {});
+        await Future.delayed(const Duration(milliseconds: 600));
+        sub1.cancel();
+        callLog.clear();
+
+        // Second subscription — backoff should restart from initialDelay.
+        final sub2 = checker.onStatusChange.listen((_) {});
+        await Future.delayed(const Duration(milliseconds: 400));
+        sub2.cancel();
+
+        // With restarted backoff (50 → 100 → 200ms), we expect fewer calls
+        // than if the capped 200ms delay continued (which would yield ~2 calls).
+        // Actually both cases yield 2-3 calls in 400ms, so just verify
+        // that the first gap is close to initialDelay (50ms), not maxDelay.
+        if (callLog.length >= 2) {
+          final firstGap =
+              callLog[1].difference(callLog[0]).inMilliseconds.abs();
+          expect(firstGap, lessThan(180)); // initialDelay=50ms + tolerance
+        }
+      });
+
+      test('first poll returning disconnected is treated as first failure',
+          () async {
+        final callLog = <DateTime>[];
+
+        // Always disconnected from the start — previousStatus will be null on
+        // the first poll, which should be treated as first-failure (not ongoing).
+        final checker = makeChecker(
+          shouldSucceed: () => false,
+          callLog: callLog,
+          checkInterval: const Duration(milliseconds: 50),
+          backoffInitialDelay: const Duration(milliseconds: 100),
+          backoffMaxDelay: const Duration(milliseconds: 800),
+          backoffMultiplier: 2.0,
+        );
+
+        final sub = checker.onStatusChange.listen((_) {});
+
+        // First check fires immediately, then after initialDelay (100ms).
+        // If first-failure was treated as ongoing, delay would be 50*2=100ms anyway,
+        // but if it jumped to ongoing-formula on first call it would be 200ms.
+        await Future.delayed(const Duration(milliseconds: 400));
+        sub.cancel();
+
+        // We should see at least 2 calls in 400ms:
+        // call[0] immediately, call[1] after ~100ms, call[2] after ~200ms.
+        expect(callLog.length, greaterThanOrEqualTo(2));
+
+        if (callLog.length >= 2) {
+          final gap = callLog[1]
+              .difference(callLog[0])
+              .inMilliseconds
+              .abs();
+          // initialDelay is 100ms; ongoing backoff of 100ms would also be 100ms
+          // on first step, but 200ms on second. We verify the first gap is ~100ms.
+          expect(gap, greaterThan(60));
+          expect(gap, lessThan(200));
+        }
+      });
+    });
   });
 }

--- a/test/internet_connection_test.dart
+++ b/test/internet_connection_test.dart
@@ -297,7 +297,7 @@ void main() {
               customCheckOptions: singleOption,
               backoffMultiplier: 0.5,
             ),
-            throwsA(isA<AssertionError>()),
+            throwsA(isA<ArgumentError>()),
           );
         });
 
@@ -325,7 +325,7 @@ void main() {
               customCheckOptions: singleOption,
               backoffInitialDelay: Duration.zero,
             ),
-            throwsA(isA<AssertionError>()),
+            throwsA(isA<ArgumentError>()),
           );
         });
 
@@ -340,7 +340,7 @@ void main() {
               backoffInitialDelay: const Duration(seconds: 10),
               backoffMaxDelay: const Duration(seconds: 5),
             ),
-            throwsA(isA<AssertionError>()),
+            throwsA(isA<ArgumentError>()),
           );
         });
       });

--- a/test/internet_connection_test.dart
+++ b/test/internet_connection_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart';
 import 'package:test/test.dart';
 
@@ -168,7 +170,7 @@ void main() {
           // Give it tiny error space.
           expect(4 <= counter && counter <= 6, true);
 
-          sub.cancel();
+          await sub.cancel();
         });
       });
 
@@ -204,7 +206,7 @@ void main() {
 
           expect(14 <= counter && counter <= 16, true);
 
-          sub.cancel();
+          await sub.cancel();
         });
       });
 
@@ -238,7 +240,7 @@ void main() {
           // Give it tiny error space.
           expect(4 <= counter && counter <= 6, true);
 
-          sub.cancel();
+          await sub.cancel();
         });
       });
     });
@@ -251,6 +253,39 @@ void main() {
     test('createInstance constructor returns different instances', () {
       final checker = InternetConnection.createInstance();
       expect(checker, isNot(InternetConnection.createInstance()));
+    });
+
+    test('onStatusChange yields cached status immediately to new subscriber',
+        () async {
+      await TestHttpClient.run((client) async {
+        client.responseBuilder =
+            (req) => TestHttpClient.createResponse(statusCode: 200);
+
+        final checker = InternetConnection.createInstance(
+          // Long interval so no second poll fires during the test.
+          checkInterval: const Duration(seconds: 10),
+          useDefaultOptions: false,
+          customCheckOptions: [
+            InternetCheckOption(uri: Uri.parse('https://www.example.com')),
+          ],
+        );
+
+        // First subscription — wait for the initial check to complete.
+        final sub1 = checker.onStatusChange.listen((_) {});
+        await Future.delayed(const Duration(milliseconds: 100));
+        expect(checker.lastTryResults, InternetStatus.connected);
+
+        // Second subscription — should receive the cached status without a
+        // new network request (next poll is 10s away).
+        final received = <InternetStatus>[];
+        final sub2 = checker.onStatusChange.listen(received.add);
+        await Future.delayed(const Duration(milliseconds: 50));
+
+        expect(received, [InternetStatus.connected]);
+
+        await sub1.cancel();
+        await sub2.cancel();
+      });
     });
 
     group('exponentialBackoff', () {
@@ -363,7 +398,7 @@ void main() {
 
         final sub = checker.onStatusChange.listen((_) {});
         await Future.delayed(const Duration(milliseconds: 550));
-        sub.cancel();
+        await sub.cancel();
 
         // With a 100ms interval over 550ms we expect ~4-5 checks.
         expect(callLog.length, greaterThanOrEqualTo(4));
@@ -402,7 +437,7 @@ void main() {
         // cycle to elapse (~100ms for detect + ~200ms for the backoff timer).
         await Future.delayed(const Duration(milliseconds: 450));
 
-        sub.cancel();
+        await sub.cancel();
 
         // We should have at most 2 calls in this window:
         // one that detected the disconnect, and at most one more after
@@ -433,7 +468,7 @@ void main() {
 
         // Total expected time for ~4 checks: 50 + 50 + 100 + 200 = 400ms
         await Future.delayed(const Duration(milliseconds: 550));
-        sub.cancel();
+        await sub.cancel();
 
         expect(callLog.length, greaterThanOrEqualTo(4));
 
@@ -465,7 +500,7 @@ void main() {
         // Run long enough for the delay to have hit the cap and stayed there.
         // 50 + 50 + 100 + 200 + 200 = 600ms total for 5 calls.
         await Future.delayed(const Duration(milliseconds: 900));
-        sub.cancel();
+        await sub.cancel();
 
         expect(callLog.length, greaterThanOrEqualTo(4));
 
@@ -501,7 +536,7 @@ void main() {
 
         // After reconnect, polling should revert to checkInterval (50ms).
         await Future.delayed(const Duration(milliseconds: 300));
-        sub.cancel();
+        await sub.cancel();
 
         // With 50ms interval over 300ms we expect ~5 calls.
         expect(callLog.length, greaterThanOrEqualTo(3));
@@ -537,7 +572,7 @@ void main() {
         checker.setIntervalAndResetTimer(const Duration(milliseconds: 50));
 
         await Future.delayed(const Duration(milliseconds: 400));
-        sub.cancel();
+        await sub.cancel();
 
         // Should have ~3-5 calls; the gaps should be non-decreasing again
         // (restarted backoff sequence: 50, 100, 200ms…).
@@ -580,7 +615,7 @@ void main() {
         checker.setIntervalAndResetTimer(const Duration(milliseconds: 100));
 
         await Future.delayed(const Duration(milliseconds: 450));
-        sub.cancel();
+        await sub.cancel();
 
         expect(callLog.length, greaterThanOrEqualTo(2));
 
@@ -610,13 +645,13 @@ void main() {
         // First subscription — let backoff grow.
         final sub1 = checker.onStatusChange.listen((_) {});
         await Future.delayed(const Duration(milliseconds: 600));
-        sub1.cancel();
+        await sub1.cancel();
         callLog.clear();
 
         // Second subscription — backoff should restart from initialDelay.
         final sub2 = checker.onStatusChange.listen((_) {});
         await Future.delayed(const Duration(milliseconds: 400));
-        sub2.cancel();
+        await sub2.cancel();
 
         // With restarted backoff (50 → 100 → 200ms), we expect fewer calls
         // than if the capped 200ms delay continued (which would yield ~2 calls).
@@ -650,7 +685,7 @@ void main() {
         // If first-failure was treated as ongoing, delay would be 50*2=100ms anyway,
         // but if it jumped to ongoing-formula on first call it would be 200ms.
         await Future.delayed(const Duration(milliseconds: 400));
-        sub.cancel();
+        await sub.cancel();
 
         // We should see at least 2 calls in 400ms:
         // call[0] immediately, call[1] after ~100ms, call[2] after ~200ms.
@@ -663,6 +698,93 @@ void main() {
           expect(gap, greaterThan(60));
           expect(gap, lessThan(200));
         }
+      });
+
+      test(
+          'setIntervalAndResetTimer during connected period: '
+          'first subsequent failure uses initialDelay', () async {
+        bool connected = true;
+        final callLog = <DateTime>[];
+
+        final checker = makeChecker(
+          shouldSucceed: () => connected,
+          callLog: callLog,
+          checkInterval: const Duration(milliseconds: 50),
+          backoffInitialDelay: const Duration(milliseconds: 150),
+          backoffMaxDelay: const Duration(milliseconds: 800),
+          backoffMultiplier: 2.0,
+        );
+
+        final sub = checker.onStatusChange.listen((_) {});
+
+        // Establish connected state, then call setIntervalAndResetTimer
+        // while still connected.
+        await Future.delayed(const Duration(milliseconds: 100));
+        checker.setIntervalAndResetTimer(const Duration(milliseconds: 50));
+
+        // Let a few more connected polls run, then measure from the disconnect.
+        await Future.delayed(const Duration(milliseconds: 150));
+        callLog.clear();
+
+        connected = false;
+
+        // Wait for disconnect detection + one backoff cycle (initialDelay=150ms).
+        await Future.delayed(const Duration(milliseconds: 400));
+        await sub.cancel();
+
+        // The gap after the first disconnected poll should be ~initialDelay (150ms),
+        // not a grown delay.
+        if (callLog.length >= 2) {
+          final gap = callLog[1].difference(callLog[0]).inMilliseconds.abs();
+          expect(gap, greaterThan(100));
+        }
+      });
+
+      test(
+          'cancelled in-flight check does not emit stale result to new subscriber',
+          () async {
+        // Use a gate to keep the first check suspended while we cancel and
+        // resubscribe, then release it to verify the stale result is dropped.
+        final checkGate = Completer<void>();
+        var checkCount = 0;
+        final option =
+            InternetCheckOption(uri: Uri.parse('https://example.com'));
+
+        final checker = InternetConnection.createInstance(
+          checkInterval: const Duration(seconds: 10),
+          useDefaultOptions: false,
+          customCheckOptions: [option],
+          useExponentialBackoff: true,
+          customConnectivityCheck: (opt) async {
+            final mine = ++checkCount;
+            if (mine == 1) await checkGate.future; // stale check is paused
+            // check 1 → connected (stale), check 2 → disconnected (fresh)
+            return InternetCheckResult(option: opt, isSuccess: mine == 1);
+          },
+        );
+
+        // Subscribe — starts the first (paused) check.
+        final sub1 = checker.onStatusChange.listen((_) {});
+        await Future.microtask(() {});
+
+        // Cancel before the first check resolves.
+        await sub1.cancel();
+
+        // Resubscribe — starts the second (immediate, disconnected) check.
+        final received = <InternetStatus>[];
+        final sub2 = checker.onStatusChange.listen(received.add);
+
+        // Let the second check complete.
+        await Future.delayed(const Duration(milliseconds: 50));
+
+        // Release the stale first check.
+        checkGate.complete();
+        await Future.delayed(const Duration(milliseconds: 50));
+
+        // Only the fresh (disconnected) result should have been emitted.
+        expect(received, [InternetStatus.disconnected]);
+
+        await sub2.cancel();
       });
     });
   });

--- a/test/internet_connection_test.dart
+++ b/test/internet_connection_test.dart
@@ -481,6 +481,49 @@ void main() {
         }
       });
 
+      test('setIntervalAndResetTimer syncs implicit backoffInitialDelay', () async {
+        final callLog = <DateTime>[];
+
+        // Intentionally omit `backoffInitialDelay` and rely on `checkInterval` (50ms)
+        final checker = InternetConnection.createInstance(
+          checkInterval: const Duration(milliseconds: 50),
+          useDefaultOptions: false,
+          customCheckOptions: [
+            InternetCheckOption(uri: Uri.parse('https://example.com')),
+          ],
+          useExponentialBackoff: true,
+          backoffMaxDelay: const Duration(milliseconds: 500),
+          backoffMultiplier: 2.0,
+          customConnectivityCheck: (opt) async {
+            callLog.add(DateTime.now());
+            return InternetCheckResult(option: opt, isSuccess: false);
+          },
+        );
+
+        final sub = checker.onStatusChange.listen((_) {});
+
+        // Trigger the first failure
+        await Future.delayed(const Duration(milliseconds: 100));
+        callLog.clear();
+
+        // Change the interval to 100ms
+        // Since it's an implicit initial delay, _backoffInitialDelay should also follow 100ms
+        checker.setIntervalAndResetTimer(const Duration(milliseconds: 100));
+
+        await Future.delayed(const Duration(milliseconds: 450));
+        sub.cancel();
+
+        expect(callLog.length, greaterThanOrEqualTo(2));
+        
+        if (callLog.length >= 2) {
+          final firstGap = callLog[1].difference(callLog[0]).inMilliseconds.abs();
+          
+          // If it follows, it should be around 100ms; if not, it would be around 50ms
+          // Verify that it is greater than 80ms to ensure it followed 100ms
+          expect(firstGap, greaterThan(80));
+        }
+      });
+
       test('re-subscription resets backoff state', () async {
         bool connected = false;
         final callLog = <DateTime>[];

--- a/test/internet_connection_test.dart
+++ b/test/internet_connection_test.dart
@@ -304,6 +304,8 @@ void main() {
 
         await sub1.cancel();
         await sub2.cancel();
+
+        await checker.dispose();
       });
     });
 
@@ -320,7 +322,7 @@ void main() {
       }) {
         final option =
             InternetCheckOption(uri: Uri.parse('https://example.com'));
-        return InternetConnection.createInstance(
+        final checker = InternetConnection.createInstance(
           checkInterval: checkInterval,
           useDefaultOptions: false,
           customCheckOptions: [option],
@@ -333,6 +335,8 @@ void main() {
             return InternetCheckResult(option: opt, isSuccess: shouldSucceed());
           },
         );
+        addTearDown(checker.dispose);
+        return checker;
       }
 
       group('constructor validation', () {

--- a/test/internet_connection_test.dart
+++ b/test/internet_connection_test.dart
@@ -723,53 +723,6 @@ void main() {
           expect(gap, greaterThan(100));
         }
       });
-
-      test(
-          'cancelled in-flight check does not emit stale result to new subscriber',
-          () async {
-        // Use a gate to keep the first check suspended while we cancel and
-        // resubscribe, then release it to verify the stale result is dropped.
-        final checkGate = Completer<void>();
-        var checkCount = 0;
-        final option =
-            InternetCheckOption(uri: Uri.parse('https://example.com'));
-
-        final checker = InternetConnection.createInstance(
-          checkInterval: const Duration(seconds: 10),
-          useDefaultOptions: false,
-          customCheckOptions: [option],
-          backoffOptions: ExponentialBackoffOptions(),
-          customConnectivityCheck: (opt) async {
-            final mine = ++checkCount;
-            if (mine == 1) await checkGate.future; // stale check is paused
-            // check 1 → connected (stale), check 2 → disconnected (fresh)
-            return InternetCheckResult(option: opt, isSuccess: mine == 1);
-          },
-        );
-
-        // Subscribe — starts the first (paused) check.
-        final sub1 = checker.onStatusChange.listen((_) {});
-        await Future.microtask(() {});
-
-        // Cancel before the first check resolves.
-        await sub1.cancel();
-
-        // Resubscribe — starts the second (immediate, disconnected) check.
-        final received = <InternetStatus>[];
-        final sub2 = checker.onStatusChange.listen(received.add);
-
-        // Let the second check complete.
-        await Future.delayed(const Duration(milliseconds: 50));
-
-        // Release the stale first check.
-        checkGate.complete();
-        await Future.delayed(const Duration(milliseconds: 50));
-
-        // Only the fresh (disconnected) result should have been emitted.
-        expect(received, [InternetStatus.disconnected]);
-
-        await sub2.cancel();
-      });
     });
   });
 }

--- a/test/internet_connection_test.dart
+++ b/test/internet_connection_test.dart
@@ -723,6 +723,64 @@ void main() {
           expect(gap, greaterThan(100));
         }
       });
+
+      test(
+          'setIntervalAndResetTimer during an in-flight failing check does '
+          'not corrupt the backoff reset', () async {
+        // Use a gate to keep the 3rd check suspended while we call
+        // setIntervalAndResetTimer, then release it to verify the reset it
+        // applied survives instead of being silently overwritten once that
+        // stale check finally resumes.
+        final checkGate = Completer<void>();
+        var checkCount = 0;
+        final option =
+            InternetCheckOption(uri: Uri.parse('https://example.com'));
+
+        final checker = InternetConnection.createInstance(
+          // Long enough that it can't fire during this test on its own —
+          // any check we see must come from the in-flight one resuming.
+          checkInterval: const Duration(seconds: 10),
+          useDefaultOptions: false,
+          customCheckOptions: [option],
+          backoffOptions: ExponentialBackoffOptions(
+            initialDelay: const Duration(milliseconds: 50),
+            maxDelay: const Duration(milliseconds: 800),
+            multiplier: 2.0,
+          ),
+          customConnectivityCheck: (opt) async {
+            checkCount++;
+            if (checkCount == 3) await checkGate.future; // hold check 3 open
+            return InternetCheckResult(option: opt, isSuccess: false);
+          },
+        );
+        addTearDown(checker.dispose);
+
+        final sub = checker.onStatusChange.listen((_) {});
+
+        // Let backoff grow through check 1 (50ms) and check 2 (100ms), then
+        // check 3 starts and gets held.
+        await Future.delayed(const Duration(milliseconds: 200));
+        expect(checkCount, 3);
+
+        // Reset while check 3 is still in-flight. This should make the next
+        // failure use the fresh initial delay (50ms) again.
+        checker.setIntervalAndResetTimer(const Duration(seconds: 10));
+        expect(checker.currentBackoffDelay, const Duration(milliseconds: 50));
+
+        // Release the stale check.
+        checkGate.complete();
+        await Future.delayed(const Duration(milliseconds: 300));
+        await sub.cancel();
+
+        // Without a guard, check 3 resuming would treat the reset as its own
+        // first-failure, consume it, and reschedule — so the *next* check
+        // would incorrectly see the reset as already used and grow the
+        // delay to 100ms instead of starting over at 50ms. It would also
+        // fire that extra check well within this 300ms window (the new
+        // 10-second interval could not have fired on its own).
+        expect(checkCount, 3);
+        expect(checker.currentBackoffDelay, const Duration(milliseconds: 50));
+      });
     });
   });
 }

--- a/test/internet_connection_test.dart
+++ b/test/internet_connection_test.dart
@@ -401,6 +401,56 @@ void main() {
             throwsA(isA<ArgumentError>()),
           );
         });
+
+        // NaN and Infinity both fail `< 1.0` (IEEE-754 comparisons involving
+        // NaN are always false), so a naive lower-bound check alone would let
+        // them through the constructor only to crash later when `.round()` is
+        // called on the grown delay during an ongoing failure.
+        test('throws when backoffMultiplier is NaN', () {
+          expect(
+            () => InternetConnection.createInstance(
+              useExponentialBackoff: true,
+              useDefaultOptions: false,
+              customCheckOptions: singleOption,
+              backoffMultiplier: double.nan,
+            ),
+            throwsA(isA<ArgumentError>()),
+          );
+        });
+
+        test('throws when backoffMultiplier is Infinity', () {
+          expect(
+            () => InternetConnection.createInstance(
+              useExponentialBackoff: true,
+              useDefaultOptions: false,
+              customCheckOptions: singleOption,
+              backoffMultiplier: double.infinity,
+            ),
+            throwsA(isA<ArgumentError>()),
+          );
+        });
+      });
+
+      test('exposes the effective backoff configuration via public getters',
+          () async {
+        final checker = InternetConnection.createInstance(
+          checkInterval: const Duration(seconds: 10),
+          useDefaultOptions: false,
+          customCheckOptions: [
+            InternetCheckOption(uri: Uri.parse('https://example.com')),
+          ],
+          useExponentialBackoff: true,
+          backoffMaxDelay: const Duration(seconds: 30),
+          backoffMultiplier: 3.0,
+        );
+        addTearDown(checker.dispose);
+
+        // backoffInitialDelay was omitted, so it should track checkInterval.
+        expect(checker.backoffInitialDelay, const Duration(seconds: 10));
+        expect(checker.backoffMaxDelay, const Duration(seconds: 30));
+        expect(checker.backoffMultiplier, 3.0);
+        // Before any failure, the live delay equals the initial delay.
+        expect(checker.currentBackoffDelay, const Duration(seconds: 10));
       });
 
       test('disabled by default: interval stays constant under failures',

--- a/test/internet_connection_test.dart
+++ b/test/internet_connection_test.dart
@@ -326,10 +326,11 @@ void main() {
           checkInterval: checkInterval,
           useDefaultOptions: false,
           customCheckOptions: [option],
-          useExponentialBackoff: true,
-          backoffInitialDelay: backoffInitialDelay,
-          backoffMaxDelay: backoffMaxDelay,
-          backoffMultiplier: backoffMultiplier,
+          backoffOptions: ExponentialBackoffOptions(
+            initialDelay: backoffInitialDelay,
+            maxDelay: backoffMaxDelay,
+            multiplier: backoffMultiplier,
+          ),
           customConnectivityCheck: (opt) async {
             callLog.add(DateTime.now());
             return InternetCheckResult(option: opt, isSuccess: shouldSucceed());
@@ -339,98 +340,6 @@ void main() {
         return checker;
       }
 
-      group('constructor validation', () {
-        // One custom option is enough to satisfy the non-default-options assert.
-        final singleOption = [
-          InternetCheckOption(uri: Uri.parse('https://example.com')),
-        ];
-
-        // backoffMultiplier < 1.0 would cause the delay to shrink on each
-        // failure, eventually collapsing to 0 and creating a busy-poll loop.
-        test('throws when backoffMultiplier is less than 1.0', () {
-          expect(
-            () => InternetConnection.createInstance(
-              useExponentialBackoff: true,
-              useDefaultOptions: false,
-              customCheckOptions: singleOption,
-              backoffMultiplier: 0.5,
-            ),
-            throwsA(isA<ArgumentError>()),
-          );
-        });
-
-        // 1.0 is the boundary: flat-rate backoff (delay never grows) is valid,
-        // since the interval still resets on reconnect as documented.
-        test('allows backoffMultiplier equal to 1.0', () {
-          expect(
-            () => InternetConnection.createInstance(
-              useExponentialBackoff: true,
-              useDefaultOptions: false,
-              customCheckOptions: singleOption,
-              backoffMultiplier: 1.0,
-            ),
-            returnsNormally,
-          );
-        });
-
-        // Duration.zero initial delay fires the next timer immediately on the
-        // first failure, indistinguishable from having no backoff at all.
-        test('throws when backoffInitialDelay is zero', () {
-          expect(
-            () => InternetConnection.createInstance(
-              useExponentialBackoff: true,
-              useDefaultOptions: false,
-              customCheckOptions: singleOption,
-              backoffInitialDelay: Duration.zero,
-            ),
-            throwsA(isA<ArgumentError>()),
-          );
-        });
-
-        // initialDelay > maxDelay means the very first backed-off poll already
-        // exceeds the configured ceiling — the ceiling becomes meaningless.
-        test('throws when backoffInitialDelay exceeds backoffMaxDelay', () {
-          expect(
-            () => InternetConnection.createInstance(
-              useExponentialBackoff: true,
-              useDefaultOptions: false,
-              customCheckOptions: singleOption,
-              backoffInitialDelay: const Duration(seconds: 10),
-              backoffMaxDelay: const Duration(seconds: 5),
-            ),
-            throwsA(isA<ArgumentError>()),
-          );
-        });
-
-        // NaN and Infinity both fail `< 1.0` (IEEE-754 comparisons involving
-        // NaN are always false), so a naive lower-bound check alone would let
-        // them through the constructor only to crash later when `.round()` is
-        // called on the grown delay during an ongoing failure.
-        test('throws when backoffMultiplier is NaN', () {
-          expect(
-            () => InternetConnection.createInstance(
-              useExponentialBackoff: true,
-              useDefaultOptions: false,
-              customCheckOptions: singleOption,
-              backoffMultiplier: double.nan,
-            ),
-            throwsA(isA<ArgumentError>()),
-          );
-        });
-
-        test('throws when backoffMultiplier is Infinity', () {
-          expect(
-            () => InternetConnection.createInstance(
-              useExponentialBackoff: true,
-              useDefaultOptions: false,
-              customCheckOptions: singleOption,
-              backoffMultiplier: double.infinity,
-            ),
-            throwsA(isA<ArgumentError>()),
-          );
-        });
-      });
-
       test('exposes the effective backoff configuration via public getters',
           () async {
         final checker = InternetConnection.createInstance(
@@ -439,16 +348,17 @@ void main() {
           customCheckOptions: [
             InternetCheckOption(uri: Uri.parse('https://example.com')),
           ],
-          useExponentialBackoff: true,
-          backoffMaxDelay: const Duration(seconds: 30),
-          backoffMultiplier: 3.0,
+          backoffOptions: ExponentialBackoffOptions(
+            maxDelay: const Duration(seconds: 30),
+            multiplier: 3.0,
+          ),
         );
         addTearDown(checker.dispose);
 
-        // backoffInitialDelay was omitted, so it should track checkInterval.
-        expect(checker.backoffInitialDelay, const Duration(seconds: 10));
-        expect(checker.backoffMaxDelay, const Duration(seconds: 30));
-        expect(checker.backoffMultiplier, 3.0);
+        // initialDelay was omitted, so it should track checkInterval.
+        expect(checker.backoffOptions!.initialDelay, null);
+        expect(checker.backoffOptions!.maxDelay, const Duration(seconds: 30));
+        expect(checker.backoffOptions!.multiplier, 3.0);
         // Before any failure, the live delay equals the initial delay.
         expect(checker.currentBackoffDelay, const Duration(seconds: 10));
       });
@@ -668,9 +578,10 @@ void main() {
           customCheckOptions: [
             InternetCheckOption(uri: Uri.parse('https://example.com')),
           ],
-          useExponentialBackoff: true,
-          backoffMaxDelay: const Duration(milliseconds: 500),
-          backoffMultiplier: 2.0,
+          backoffOptions: ExponentialBackoffOptions(
+            maxDelay: const Duration(milliseconds: 500),
+            multiplier: 2.0,
+          ),
           customConnectivityCheck: (opt) async {
             callLog.add(DateTime.now());
             return InternetCheckResult(option: opt, isSuccess: false);
@@ -827,7 +738,7 @@ void main() {
           checkInterval: const Duration(seconds: 10),
           useDefaultOptions: false,
           customCheckOptions: [option],
-          useExponentialBackoff: true,
+          backoffOptions: ExponentialBackoffOptions(),
           customConnectivityCheck: (opt) async {
             final mine = ++checkCount;
             if (mine == 1) await checkGate.future; // stale check is paused


### PR DESCRIPTION
Hi @OutdatedGuy! Thanks for maintaining this awesome package.

Closes #99

## Problem

The `onStatusChange` polling loop retries at a fixed `checkInterval` (default 10 s) regardless of connection state. During extended outages this results in unnecessary battery drain, wasted CPU cycles, and pointless network traffic on mobile devices.

## Analysis

Inspecting `_maybeEmitStatusUpdate()` in `lib/src/internet_connection.dart` confirmed the timer is always rescheduled with the same `_checkInterval`:

```
_maybeEmitStatusUpdate()
  └─ await internetStatus
  └─ if status changed → emit
  └─ Timer(_checkInterval, _maybeEmitStatusUpdate)  // always the same value
```

Key design constraints identified before implementation:

- `_lastStatus` is mutated inside `_maybeEmitStatusUpdate`, so distinguishing "first failure" from "ongoing failure" requires snapshotting its value before the update.
- All new parameters must default to "backoff disabled" (`useExponentialBackoff = false`) to leave the singleton `InternetConnection()` and existing callers completely unaffected.
- Backoff state must reset on reconnect, on `setIntervalAndResetTimer()`, and on last-listener cancel.
- When `backoffInitialDelay` is not explicitly provided, it should track `_checkInterval` so a `setIntervalAndResetTimer()` call does not leave a stale initial delay from construction time.

## Changes

**Files modified:**
- `lib/src/internet_connection.dart`
- `test/internet_connection_test.dart`

### New `createInstance` parameters

| Parameter | Type | Default | Description |
|---|---|---|---|
| `useExponentialBackoff` | `bool` | `false` | Opt-in flag; `false` preserves existing behaviour exactly |
| `backoffInitialDelay` | `Duration?` | same as `checkInterval` | Delay applied after the first failure |
| `backoffMaxDelay` | `Duration` | `Duration(seconds: 60)` | Upper bound on the retry interval |
| `backoffMultiplier` | `double` | `2.0` | Factor applied to the delay on each consecutive failure |

### Backoff logic

```
first failure    → nextDelay = backoffInitialDelay
ongoing failure  → nextDelay = min(currentDelay × multiplier, maxDelay)
reconnect        → nextDelay = checkInterval  (reset)
```

`previousStatus` is snapshotted before the `_lastStatus` mutation so that the branch correctly identifies the first failure even when `previousStatus` is `null` (very first poll):

```dart
final previousStatus = _lastStatus;  // snapshot before mutation

// ... _lastStatus update ...

if (useExponentialBackoff) {
  if (currentStatus == InternetStatus.connected) {
    _currentBackoffDelay = _backoffInitialDelay;
    nextDelay = _checkInterval;
  } else if (previousStatus != InternetStatus.disconnected) {
    // First failure: previousStatus is null (initial poll) or connected.
    _currentBackoffDelay = _backoffInitialDelay;
    nextDelay = _currentBackoffDelay;
  } else {
    // Ongoing failure: grow the delay.
    final ms = (_currentBackoffDelay.inMilliseconds * _backoffMultiplier).round();
    _currentBackoffDelay = Duration(
      milliseconds: ms.clamp(0, _backoffMaxDelay.inMilliseconds).toInt(),
    );
    nextDelay = _currentBackoffDelay;
  }
}
```

> `.toInt()` is appended to `.clamp()` as a defensive cast: `ms` is `int` in current Dart, but `num.clamp` can return `num` depending on the Dart version or analyzer strictness, which would cause a type error on the `milliseconds:` field.

### Backoff state reset conditions

| Trigger | Behaviour |
|---|---|
| `currentStatus == connected` | Reset `_currentBackoffDelay` to `_backoffInitialDelay` |
| `setIntervalAndResetTimer(duration)` | If `backoffInitialDelay` was not explicitly provided, also update `_backoffInitialDelay` to `duration` before resetting `_currentBackoffDelay`; otherwise keep the caller-specified value |
| Last listener cancelled (`_handleStatusChangeCancel`) | Reset `_currentBackoffDelay` to `_backoffInitialDelay` so the next subscription starts clean |

The `backoffInitialDelay` tracking is implemented with a `final bool _backoffInitialDelayExplicit` flag set in the initializer list. When `false`, `_backoffInitialDelay` is updated in `setIntervalAndResetTimer` to stay in sync with `_checkInterval`, preventing a stale initial delay from lingering after the interval is changed dynamically.

### Usage example

```dart
final connection = InternetConnection.createInstance(
  checkInterval: const Duration(seconds: 10),
  useExponentialBackoff: true,
  backoffInitialDelay: const Duration(seconds: 10),
  backoffMaxDelay: const Duration(minutes: 1),
  backoffMultiplier: 2.0,
);
// Retry delays on failure: 10s → 20s → 40s → 60s → 60s → ...
// Resets to 10s immediately on reconnect.
```

## Tests

Added `group('exponentialBackoff', ...)` to `test/internet_connection_test.dart`. Tests use `customConnectivityCheck` with `DateTime.now()` call logging to avoid real network calls and enable deterministic timing assertions.

| Test case | What it verifies |
|---|---|
| disabled by default | Fixed interval is preserved with backoff off (regression guard) |
| first failure sets initialDelay | `backoffInitialDelay` is used on the first disconnect |
| delay grows on consecutive failures | Gaps between calls are monotonically non-decreasing |
| delay is capped at maxDelay | No gap exceeds `backoffMaxDelay` |
| delay resets to checkInterval on reconnect | Interval reverts to `checkInterval` after reconnect |
| setIntervalAndResetTimer resets backoff | Backoff sequence restarts from `backoffInitialDelay` after interval change |
| re-subscription resets backoff | Cancel + re-listen starts the backoff sequence from the beginning |
| first poll returning disconnected | `previousStatus == null` is treated as first failure, not ongoing |

```
dart test              →  30/30 passed
dart analyze lib/ test/ →  No issues found
```
