### PR TITLE
fix(polling): drop stale in-flight check results on cancel/resubscribe

### DIFF
--- a/lib/src/internet_connection.dart
+++ b/lib/src/internet_connection.dart
@@ -279,25 +279,18 @@ class InternetConnection {
 
     if (!_statusController.hasListener) return;
 
-    final subscriptionVersion = _subscriptionVersion;
+    final previousSubVersion = _subscriptionVersion;
 
     final currentStatus = await internetStatus;
 
-    // If a listener cancelled (and maybe a new one subscribed) while the
-    // check above was running, this result belongs to the old listener and
-    // must not be sent to whoever is listening now.
-    final isStale = _subscriptionVersion != subscriptionVersion;
+    if (!_statusController.hasListener) return;
 
-    if (!isStale &&
-        _lastStatus != currentStatus &&
-        _statusController.hasListener) {
+    final isStale = _subscriptionVersion != previousSubVersion;
+
+    if (!isStale && _lastStatus != currentStatus) {
       _lastStatus = currentStatus;
       _statusController.add(currentStatus);
     }
-
-    // A listener may have cancelled while the check above was running. Don't
-    // start a new timer in that case — there's nobody left to notify.
-    if (!_statusController.hasListener) return;
 
     _timerHandle = Timer(_checkInterval, _maybeEmitStatusUpdate);
   }

--- a/lib/src/internet_connection.dart
+++ b/lib/src/internet_connection.dart
@@ -283,11 +283,12 @@ class InternetConnection {
 
     final currentStatus = await internetStatus;
 
-    if (!_statusController.hasListener) return;
+    if (!_statusController.hasListener ||
+        _subscriptionVersion != previousSubVersion) {
+      return;
+    }
 
-    final isStale = _subscriptionVersion != previousSubVersion;
-
-    if (!isStale && _lastStatus != currentStatus) {
+    if (_lastStatus != currentStatus) {
       _lastStatus = currentStatus;
       _statusController.add(currentStatus);
     }
@@ -299,12 +300,12 @@ class InternetConnection {
   ///
   /// Cancels the timer and resets the last status.
   Future<void> _handleStatusChangeCancel() async {
-    await _triggerSubscription?.cancel();
-    _triggerSubscription = null;
     _subscriptionVersion++;
     _timerHandle?.cancel();
     _timerHandle = null;
     _lastStatus = null;
+    await _triggerSubscription?.cancel();
+    _triggerSubscription = null;
   }
 
   /// The result of the last attempt to check the internet status.

--- a/lib/src/internet_connection.dart
+++ b/lib/src/internet_connection.dart
@@ -176,6 +176,16 @@ class InternetConnection {
   /// The handle for the timer used for periodic status checks.
   Timer? _timerHandle;
 
+  /// A counter that goes up by 1 every time a listener cancels its
+  /// subscription (see [_handleStatusChangeCancel]).
+  ///
+  /// [_maybeEmitStatusUpdate] reads this value before it starts checking the
+  /// connection, then compares it again after the check finishes. If the
+  /// numbers don't match, a cancel (and possibly a resubscribe) happened
+  /// while the check was still running, so that check's result is thrown
+  /// away instead of being sent to whoever is listening now.
+  int _subscriptionVersion = 0;
+
   /// Checks if the [Uri] specified in [option] is reachable.
   ///
   /// Returns a [Future] that completes with an [InternetCheckResult] indicating
@@ -269,12 +279,25 @@ class InternetConnection {
 
     if (!_statusController.hasListener) return;
 
+    final subscriptionVersion = _subscriptionVersion;
+
     final currentStatus = await internetStatus;
 
-    if (_lastStatus != currentStatus && _statusController.hasListener) {
+    // If a listener cancelled (and maybe a new one subscribed) while the
+    // check above was running, this result belongs to the old listener and
+    // must not be sent to whoever is listening now.
+    final isStale = _subscriptionVersion != subscriptionVersion;
+
+    if (!isStale &&
+        _lastStatus != currentStatus &&
+        _statusController.hasListener) {
       _lastStatus = currentStatus;
       _statusController.add(currentStatus);
     }
+
+    // A listener may have cancelled while the check above was running. Don't
+    // start a new timer in that case — there's nobody left to notify.
+    if (!_statusController.hasListener) return;
 
     _timerHandle = Timer(_checkInterval, _maybeEmitStatusUpdate);
   }
@@ -285,6 +308,7 @@ class InternetConnection {
   Future<void> _handleStatusChangeCancel() async {
     await _triggerSubscription?.cancel();
     _triggerSubscription = null;
+    _subscriptionVersion++;
     _timerHandle?.cancel();
     _timerHandle = null;
     _lastStatus = null;

--- a/test/internet_connection_test.dart
+++ b/test/internet_connection_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart';
 import 'package:test/test.dart';
 
@@ -270,6 +272,90 @@ void main() {
       expect(checker, isNot(InternetConnection.createInstance()));
 
       await checker.dispose();
+    });
+
+    group('onStatusChange', () {
+      test(
+          'cancelled in-flight check does not emit stale result to new subscriber',
+          () async {
+        // Use a gate to keep the first check suspended while we cancel and
+        // resubscribe, then release it to verify the stale result is dropped.
+        final checkGate = Completer<void>();
+        var checkCount = 0;
+        final option =
+            InternetCheckOption(uri: Uri.parse('https://example.com'));
+
+        final checker = InternetConnection.createInstance(
+          checkInterval: const Duration(seconds: 10),
+          useDefaultOptions: false,
+          customCheckOptions: [option],
+          customConnectivityCheck: (opt) async {
+            final mine = ++checkCount;
+            if (mine == 1) await checkGate.future; // stale check is paused
+            // check 1 → connected (stale), check 2 → disconnected (fresh)
+            return InternetCheckResult(option: opt, isSuccess: mine == 1);
+          },
+        );
+
+        // Subscribe — starts the first (paused) check.
+        final sub1 = checker.onStatusChange.listen((_) {});
+        await Future.microtask(() {});
+
+        // Cancel before the first check resolves.
+        await sub1.cancel();
+
+        // Resubscribe — starts the second (immediate, disconnected) check.
+        final received = <InternetStatus>[];
+        final sub2 = checker.onStatusChange.listen(received.add);
+
+        // Let the second check complete.
+        await Future.delayed(const Duration(milliseconds: 50));
+
+        // Release the stale first check.
+        checkGate.complete();
+        await Future.delayed(const Duration(milliseconds: 50));
+
+        // Only the fresh (disconnected) result should have been emitted.
+        expect(received, [InternetStatus.disconnected]);
+
+        await sub2.cancel();
+        await checker.dispose();
+      });
+
+      test('does not restart the timer if cancelled while a check is in-flight',
+          () async {
+        final checkGate = Completer<void>();
+        var checkCount = 0;
+        final option =
+            InternetCheckOption(uri: Uri.parse('https://example.com'));
+
+        final checker = InternetConnection.createInstance(
+          checkInterval: const Duration(milliseconds: 50),
+          useDefaultOptions: false,
+          customCheckOptions: [option],
+          customConnectivityCheck: (opt) async {
+            checkCount++;
+            if (checkCount == 1) await checkGate.future;
+            return InternetCheckResult(option: opt, isSuccess: true);
+          },
+        );
+
+        final sub = checker.onStatusChange.listen((_) {});
+        await Future.microtask(() {});
+
+        // Cancel while the first check is still in-flight.
+        await sub.cancel();
+
+        // Release the in-flight check now that there are no listeners.
+        checkGate.complete();
+        await Future.delayed(const Duration(milliseconds: 200));
+
+        // No listener ever subscribed again, so no further checks should
+        // have been triggered by a lingering timer.
+        expect(checkCount, 1);
+
+        await checker.dispose();
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary

Split out from #139 per review feedback, with `_cancelGeneration` renamed to `_subscriptionVersion`.

If a listener cancels its subscription while a connectivity check is still running, that check's result belongs to the old subscription. Without a guard:
- it could still get emitted to a brand-new subscriber that started its own fresh check moments later, or
- it could restart the polling timer even though nobody is listening anymore.

This adds a `_subscriptionVersion` counter, bumped only when a listener cancels. `_maybeEmitStatusUpdate` snapshots it before the check starts and skips both the emit and the next timer reschedule if it changed while the check was in-flight.

## Test plan

- [x] `dart analyze` — no issues
- [x] `dart format --set-exit-if-changed` — clean
- [x] `dart test` — all tests pass, including two new regression tests:
  - cancelled in-flight check does not emit stale result to new subscriber
  - does not restart the timer if cancelled while a check is in-flight